### PR TITLE
[UI/YAF-30] 알람 설정 시 'Time / Hour / Minute' 을 조정하도록 한다

### DIFF
--- a/core/ui/src/main/java/com/yapp/ui/component/timepicker/OrbitPicker.kt
+++ b/core/ui/src/main/java/com/yapp/ui/component/timepicker/OrbitPicker.kt
@@ -50,7 +50,6 @@ fun OrbitPicker(
             val minutePickerState = rememberPickerState()
 
             Box(modifier = Modifier.fillMaxWidth()) {
-                // 배경 박스
                 Box(
                     modifier = Modifier
                         .fillMaxWidth()

--- a/core/ui/src/main/java/com/yapp/ui/component/timepicker/OrbitPicker.kt
+++ b/core/ui/src/main/java/com/yapp/ui/component/timepicker/OrbitPicker.kt
@@ -1,5 +1,6 @@
 package com.yapp.ui.component.timepicker
 
+import android.util.Log
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -26,6 +27,7 @@ import java.util.Locale
 fun OrbitPicker(
     modifier: Modifier = Modifier,
     itemSpacing: Dp = 2.dp,
+    onValueChange: (String, Int, Int) -> Unit
 ) {
     Surface(
         modifier = modifier
@@ -47,9 +49,8 @@ fun OrbitPicker(
             val hourPickerState = rememberPickerState()
             val minutePickerState = rememberPickerState()
 
-            Box(
-                modifier = Modifier.fillMaxWidth(),
-            ) {
+            Box(modifier = Modifier.fillMaxWidth()) {
+                // 배경 박스
                 Box(
                     modifier = Modifier
                         .fillMaxWidth()
@@ -58,6 +59,7 @@ fun OrbitPicker(
                         .height(50.dp)
                         .background(OrbitTheme.colors.gray_700, shape = RoundedCornerShape(12.dp)),
                 )
+
                 Row(
                     modifier = Modifier
                         .fillMaxWidth()
@@ -68,31 +70,48 @@ fun OrbitPicker(
                         state = amPmPickerState,
                         items = amPmItems,
                         visibleItemsCount = 3,
-                        infiniteScroll = false,
+                        itemSpacing = itemSpacing,
+                        textStyle = OrbitTheme.typography.title2Medium,
                         modifier = Modifier.weight(1f),
                         textModifier = Modifier.padding(8.dp),
-                        textStyle = OrbitTheme.typography.title2Medium,
-                        itemSpacing = itemSpacing,
+                        infiniteScroll = false,
+                        onValueChange = {
+                            onPickerValueChange(
+                                amPmPickerState, hourPickerState, minutePickerState, onValueChange
+                            )
+                        }
                     )
+
                     OrbitPickerItem(
                         state = hourPickerState,
                         items = hourItems,
                         visibleItemsCount = 5,
-                        infiniteScroll = true,
+                        itemSpacing = itemSpacing,
+                        textStyle = OrbitTheme.typography.title2Medium,
                         modifier = Modifier.weight(1f),
                         textModifier = Modifier.padding(8.dp),
-                        textStyle = OrbitTheme.typography.title2Medium,
-                        itemSpacing = itemSpacing,
+                        infiniteScroll = true,
+                        onValueChange = {
+                            onPickerValueChange(
+                                amPmPickerState, hourPickerState, minutePickerState, onValueChange
+                            )
+                        }
                     )
+
                     OrbitPickerItem(
                         state = minutePickerState,
                         items = minuteItems,
                         visibleItemsCount = 5,
-                        infiniteScroll = true,
+                        itemSpacing = itemSpacing,
+                        textStyle = OrbitTheme.typography.title2Medium,
                         modifier = Modifier.weight(1f),
                         textModifier = Modifier.padding(8.dp),
-                        textStyle = OrbitTheme.typography.title2Medium,
-                        itemSpacing = itemSpacing,
+                        infiniteScroll = true,
+                        onValueChange = {
+                            onPickerValueChange(
+                                amPmPickerState, hourPickerState, minutePickerState, onValueChange
+                            )
+                        }
                     )
                 }
             }
@@ -100,8 +119,22 @@ fun OrbitPicker(
     }
 }
 
+private fun onPickerValueChange(
+    amPmState: PickerState,
+    hourState: PickerState,
+    minuteState: PickerState,
+    onValueChange: (String, Int, Int) -> Unit
+) {
+    val amPm = amPmState.selectedItem
+    val hour = hourState.selectedItem.toIntOrNull() ?: 0
+    val minute = minuteState.selectedItem.toIntOrNull() ?: 0
+    onValueChange(amPm, hour, minute)
+}
+
 @Preview(showBackground = true)
 @Composable
 fun BottomSheetPickerPreview() {
-    OrbitPicker()
+    OrbitPicker { amPm, hour, minute ->
+        Log.d("OrbitPicker", "amPm: $amPm, hour: $hour, minute: $minute")
+    }
 }

--- a/core/ui/src/main/java/com/yapp/ui/component/timepicker/OrbitPicker.kt
+++ b/core/ui/src/main/java/com/yapp/ui/component/timepicker/OrbitPicker.kt
@@ -27,7 +27,7 @@ import java.util.Locale
 fun OrbitPicker(
     modifier: Modifier = Modifier,
     itemSpacing: Dp = 2.dp,
-    onValueChange: (String, Int, Int) -> Unit
+    onValueChange: (String, Int, Int) -> Unit,
 ) {
     Surface(
         modifier = modifier
@@ -77,9 +77,12 @@ fun OrbitPicker(
                         infiniteScroll = false,
                         onValueChange = {
                             onPickerValueChange(
-                                amPmPickerState, hourPickerState, minutePickerState, onValueChange
+                                amPmPickerState,
+                                hourPickerState,
+                                minutePickerState,
+                                onValueChange,
                             )
-                        }
+                        },
                     )
 
                     OrbitPickerItem(
@@ -93,9 +96,12 @@ fun OrbitPicker(
                         infiniteScroll = true,
                         onValueChange = {
                             onPickerValueChange(
-                                amPmPickerState, hourPickerState, minutePickerState, onValueChange
+                                amPmPickerState,
+                                hourPickerState,
+                                minutePickerState,
+                                onValueChange,
                             )
-                        }
+                        },
                     )
 
                     OrbitPickerItem(
@@ -109,9 +115,12 @@ fun OrbitPicker(
                         infiniteScroll = true,
                         onValueChange = {
                             onPickerValueChange(
-                                amPmPickerState, hourPickerState, minutePickerState, onValueChange
+                                amPmPickerState,
+                                hourPickerState,
+                                minutePickerState,
+                                onValueChange,
                             )
-                        }
+                        },
                     )
                 }
             }
@@ -123,7 +132,7 @@ private fun onPickerValueChange(
     amPmState: PickerState,
     hourState: PickerState,
     minuteState: PickerState,
-    onValueChange: (String, Int, Int) -> Unit
+    onValueChange: (String, Int, Int) -> Unit,
 ) {
     val amPm = amPmState.selectedItem
     val hour = hourState.selectedItem.toIntOrNull() ?: 0

--- a/core/ui/src/main/java/com/yapp/ui/component/timepicker/OrbitPickerItem.kt
+++ b/core/ui/src/main/java/com/yapp/ui/component/timepicker/OrbitPickerItem.kt
@@ -41,6 +41,7 @@ fun OrbitPickerItem(
     infiniteScroll: Boolean = true,
     textStyle: TextStyle,
     itemSpacing: Dp,
+    onValueChange: (String) -> Unit,
 ) {
     val visibleItemsMiddle = visibleItemsCount / 2
     val listScrollCount = if (infiniteScroll) Int.MAX_VALUE else items.size + visibleItemsMiddle * 2
@@ -72,6 +73,7 @@ fun OrbitPickerItem(
                 if (centerIndex != null) {
                     val adjustedIndex = centerIndex % items.size
                     state.selectedItem = items[adjustedIndex]
+                    onValueChange(state.selectedItem)
                 }
             }
     }
@@ -157,6 +159,7 @@ fun OrbitPickerPreview() {
             visibleItemsCount = 5,
             textStyle = TextStyle.Default,
             itemSpacing = 8.dp,
+            onValueChange = {},
         )
     }
 }

--- a/core/ui/src/main/java/com/yapp/ui/component/timepicker/OrbitPickerItem.kt
+++ b/core/ui/src/main/java/com/yapp/ui/component/timepicker/OrbitPickerItem.kt
@@ -72,8 +72,11 @@ fun OrbitPickerItem(
             .collect { centerIndex ->
                 if (centerIndex != null) {
                     val adjustedIndex = centerIndex % items.size
-                    state.selectedItem = items[adjustedIndex]
-                    onValueChange(state.selectedItem)
+                    val newValue = items[adjustedIndex]
+                    if (newValue != state.selectedItem) {
+                        state.selectedItem = newValue
+                        onValueChange(newValue)
+                    }
                 }
             }
     }

--- a/core/ui/src/main/java/com/yapp/ui/component/timepicker/OrbitYearMonthPicker.kt
+++ b/core/ui/src/main/java/com/yapp/ui/component/timepicker/OrbitYearMonthPicker.kt
@@ -29,7 +29,7 @@ import java.util.Locale
 fun OrbitYearMonthPicker(
     modifier: Modifier = Modifier,
     itemSpacing: Dp = 12.dp,
-    onValueChange: (String, Int, Int, Int) -> Unit
+    onValueChange: (String, Int, Int, Int) -> Unit,
 ) {
     val screenWidth = LocalConfiguration.current.screenWidthDp.dp
 
@@ -83,7 +83,7 @@ fun OrbitYearMonthPicker(
                         modifier = Modifier.width(screenWidth * 0.2f),
                         textModifier = Modifier.padding(8.dp),
                         infiniteScroll = false,
-                        onValueChange = { onPickerValueChange(lunarPickerState, yearPickerState, monthPickerState, dayPickerState, onValueChange) }
+                        onValueChange = { onPickerValueChange(lunarPickerState, yearPickerState, monthPickerState, dayPickerState, onValueChange) },
                     )
                     OrbitPickerItem(
                         state = yearPickerState,
@@ -95,7 +95,7 @@ fun OrbitYearMonthPicker(
                         modifier = Modifier.width(screenWidth * 0.25f),
                         textModifier = Modifier.padding(8.dp),
                         infiniteScroll = true,
-                        onValueChange = { onPickerValueChange(lunarPickerState, yearPickerState, monthPickerState, dayPickerState, onValueChange) }
+                        onValueChange = { onPickerValueChange(lunarPickerState, yearPickerState, monthPickerState, dayPickerState, onValueChange) },
                     )
                     OrbitPickerItem(
                         state = monthPickerState,
@@ -106,7 +106,7 @@ fun OrbitYearMonthPicker(
                         modifier = Modifier.width(screenWidth * 0.16f),
                         textModifier = Modifier.padding(8.dp),
                         infiniteScroll = true,
-                        onValueChange = { onPickerValueChange(lunarPickerState, yearPickerState, monthPickerState, dayPickerState, onValueChange) }
+                        onValueChange = { onPickerValueChange(lunarPickerState, yearPickerState, monthPickerState, dayPickerState, onValueChange) },
                     )
                     OrbitPickerItem(
                         state = dayPickerState,
@@ -117,7 +117,7 @@ fun OrbitYearMonthPicker(
                         modifier = Modifier.width(screenWidth * 0.16f),
                         textModifier = Modifier.padding(8.dp),
                         infiniteScroll = true,
-                        onValueChange = { onPickerValueChange(lunarPickerState, yearPickerState, monthPickerState, dayPickerState, onValueChange) }
+                        onValueChange = { onPickerValueChange(lunarPickerState, yearPickerState, monthPickerState, dayPickerState, onValueChange) },
                     )
                 }
             }
@@ -130,7 +130,7 @@ private fun onPickerValueChange(
     yearPickerState: PickerState,
     monthPickerState: PickerState,
     dayPickerState: PickerState,
-    onValueChange: (String, Int, Int, Int) -> Unit
+    onValueChange: (String, Int, Int, Int) -> Unit,
 ) {
     val lunar = lunarPickerState.selectedItem
     val year = yearPickerState.selectedItem.toIntOrNull() ?: 1900

--- a/core/ui/src/main/java/com/yapp/ui/component/timepicker/OrbitYearMonthPicker.kt
+++ b/core/ui/src/main/java/com/yapp/ui/component/timepicker/OrbitYearMonthPicker.kt
@@ -1,5 +1,6 @@
 package com.yapp.ui.component.timepicker
 
+import android.util.Log
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -28,6 +29,7 @@ import java.util.Locale
 fun OrbitYearMonthPicker(
     modifier: Modifier = Modifier,
     itemSpacing: Dp = 12.dp,
+    onValueChange: (String, Int, Int, Int) -> Unit
 ) {
     val screenWidth = LocalConfiguration.current.screenWidthDp.dp
 
@@ -46,9 +48,7 @@ fun OrbitYearMonthPicker(
             val lunarItems = remember { listOf("음력", "양력") }
             val yearItems = remember { (1900..2025).map { it.toString() } }
             val monthItems = remember { (1..12).map { it.toString() } }
-            val dayItems = remember {
-                (1..31).map { String.format(Locale.ROOT, "%02d", it) }
-            }
+            val dayItems = remember { (1..31).map { String.format(Locale.ROOT, "%02d", it) } }
 
             val lunarPickerState = rememberPickerState()
             val yearPickerState = rememberPickerState()
@@ -67,6 +67,7 @@ fun OrbitYearMonthPicker(
                         .height(totalItemHeight)
                         .background(OrbitTheme.colors.gray_700, shape = RoundedCornerShape(12.dp)),
                 )
+
                 Row(
                     modifier = Modifier
                         .fillMaxWidth()
@@ -77,42 +78,46 @@ fun OrbitYearMonthPicker(
                         state = lunarPickerState,
                         items = lunarItems,
                         visibleItemsCount = 3,
-                        infiniteScroll = false,
+                        itemSpacing = itemSpacing,
+                        textStyle = OrbitTheme.typography.title2SemiBold,
                         modifier = Modifier.width(screenWidth * 0.2f),
                         textModifier = Modifier.padding(8.dp),
-                        textStyle = OrbitTheme.typography.title2SemiBold,
-                        itemSpacing = itemSpacing,
+                        infiniteScroll = false,
+                        onValueChange = { onPickerValueChange(lunarPickerState, yearPickerState, monthPickerState, dayPickerState, onValueChange) }
                     )
                     OrbitPickerItem(
                         state = yearPickerState,
                         items = yearItems,
                         visibleItemsCount = 5,
-                        infiniteScroll = true,
                         startIndex = 90,
+                        itemSpacing = itemSpacing,
+                        textStyle = OrbitTheme.typography.title2SemiBold,
                         modifier = Modifier.width(screenWidth * 0.25f),
                         textModifier = Modifier.padding(8.dp),
-                        textStyle = OrbitTheme.typography.title2SemiBold,
-                        itemSpacing = itemSpacing,
+                        infiniteScroll = true,
+                        onValueChange = { onPickerValueChange(lunarPickerState, yearPickerState, monthPickerState, dayPickerState, onValueChange) }
                     )
                     OrbitPickerItem(
                         state = monthPickerState,
                         items = monthItems,
                         visibleItemsCount = 5,
-                        infiniteScroll = true,
+                        itemSpacing = itemSpacing,
+                        textStyle = OrbitTheme.typography.title2SemiBold,
                         modifier = Modifier.width(screenWidth * 0.16f),
                         textModifier = Modifier.padding(8.dp),
-                        textStyle = OrbitTheme.typography.title2SemiBold,
-                        itemSpacing = itemSpacing,
+                        infiniteScroll = true,
+                        onValueChange = { onPickerValueChange(lunarPickerState, yearPickerState, monthPickerState, dayPickerState, onValueChange) }
                     )
                     OrbitPickerItem(
                         state = dayPickerState,
                         items = dayItems,
                         visibleItemsCount = 5,
-                        infiniteScroll = true,
+                        itemSpacing = itemSpacing,
+                        textStyle = OrbitTheme.typography.title2SemiBold,
                         modifier = Modifier.width(screenWidth * 0.16f),
                         textModifier = Modifier.padding(8.dp),
-                        textStyle = OrbitTheme.typography.title2SemiBold,
-                        itemSpacing = itemSpacing,
+                        infiniteScroll = true,
+                        onValueChange = { onPickerValueChange(lunarPickerState, yearPickerState, monthPickerState, dayPickerState, onValueChange) }
                     )
                 }
             }
@@ -120,8 +125,25 @@ fun OrbitYearMonthPicker(
     }
 }
 
+private fun onPickerValueChange(
+    lunarPickerState: PickerState,
+    yearPickerState: PickerState,
+    monthPickerState: PickerState,
+    dayPickerState: PickerState,
+    onValueChange: (String, Int, Int, Int) -> Unit
+) {
+    val lunar = lunarPickerState.selectedItem
+    val year = yearPickerState.selectedItem.toIntOrNull() ?: 1900
+    val month = monthPickerState.selectedItem.toIntOrNull() ?: 1
+    val day = dayPickerState.selectedItem.toIntOrNull() ?: 1
+
+    onValueChange(lunar, year, month, day)
+}
+
 @Preview(showBackground = true)
 @Composable
 fun OrbitYearMonthPickerPreview() {
-    OrbitYearMonthPicker()
+    OrbitYearMonthPicker { lunar, year, month, day ->
+        Log.d("OrbitYearMonthPicker", "lunar: $lunar, year: $year, month: $month, day: $day")
+    }
 }

--- a/feature/home/src/main/java/com/yapp/alarm/AlarmAddEditScreen.kt
+++ b/feature/home/src/main/java/com/yapp/alarm/AlarmAddEditScreen.kt
@@ -1,0 +1,80 @@
+package com.yapp.alarm
+
+import android.util.Log
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.yapp.designsystem.theme.OrbitTheme
+import com.yapp.ui.component.timepicker.OrbitPicker
+
+@Composable
+fun AlarmAddEditRoute() {
+    AlarmAddEditScreen()
+}
+
+@Composable
+fun AlarmAddEditScreen() {
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        AlarmAddEditTopBar(
+            title = "1일 12시간 후에 울려요",
+            onBack = { }
+        )
+        OrbitPicker(
+            modifier = Modifier.padding(top = 40.dp)
+        ) { amPm, hour, minute ->
+            Log.d("AlarmAddEditScreen", "amPm: $amPm, hour: $hour, minute: $minute")
+        }
+    }
+}
+
+@Composable
+private fun AlarmAddEditTopBar(
+    title: String,
+    onBack: () -> Unit
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(56.dp)
+            .statusBarsPadding(),
+        contentAlignment = Alignment.Center,
+    ) {
+        Icon(
+            painter = painterResource(id = core.designsystem.R.drawable.ic_back),
+            contentDescription = "Back",
+            tint = OrbitTheme.colors.white,
+            modifier = Modifier
+                .clickable(onClick = onBack)
+                .padding(start = 20.dp)
+                .align(Alignment.CenterStart),
+        )
+
+        Text(
+            title,
+            style = OrbitTheme.typography.body1SemiBold,
+            color = OrbitTheme.colors.white,
+        )
+    }
+}
+
+@Preview
+@Composable
+fun AlarmAddEditScreenPreview() {
+    AlarmAddEditScreen()
+}

--- a/feature/home/src/main/java/com/yapp/alarm/AlarmAddEditScreen.kt
+++ b/feature/home/src/main/java/com/yapp/alarm/AlarmAddEditScreen.kt
@@ -29,14 +29,14 @@ fun AlarmAddEditRoute() {
 fun AlarmAddEditScreen() {
     Column(
         modifier = Modifier.fillMaxSize(),
-        horizontalAlignment = Alignment.CenterHorizontally
+        horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         AlarmAddEditTopBar(
             title = "1일 12시간 후에 울려요",
-            onBack = { }
+            onBack = { },
         )
         OrbitPicker(
-            modifier = Modifier.padding(top = 40.dp)
+            modifier = Modifier.padding(top = 40.dp),
         ) { amPm, hour, minute ->
             Log.d("AlarmAddEditScreen", "amPm: $amPm, hour: $hour, minute: $minute")
         }
@@ -46,7 +46,7 @@ fun AlarmAddEditScreen() {
 @Composable
 private fun AlarmAddEditTopBar(
     title: String,
-    onBack: () -> Unit
+    onBack: () -> Unit,
 ) {
     Box(
         modifier = Modifier

--- a/feature/home/src/main/java/com/yapp/home/HomeNavigation.kt
+++ b/feature/home/src/main/java/com/yapp/home/HomeNavigation.kt
@@ -6,6 +6,7 @@ import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
+import com.yapp.alarm.AlarmAddEditRoute
 
 fun NavController.navigateHome(navOptions: NavOptions) {
     navigate(HomeRoute.HOME, navOptions)
@@ -16,10 +17,7 @@ fun NavGraphBuilder.homeNavGraph(
     modifier: Modifier = Modifier,
 ) {
     composable(route = HomeRoute.HOME) {
-        HomeRoute(
-            padding = padding,
-            modifier = modifier,
-        )
+        AlarmAddEditRoute()
     }
 }
 

--- a/feature/navigator/src/main/java/com/yapp/navigator/MainActivity.kt
+++ b/feature/navigator/src/main/java/com/yapp/navigator/MainActivity.kt
@@ -17,7 +17,7 @@ class MainActivity : ComponentActivity() {
         setContent {
             OrbitTheme {
                 MainScreen()
-                //OnboardingRoute(onFinishOnboarding = {})
+                // OnboardingRoute(onFinishOnboarding = {})
             }
         }
     }

--- a/feature/navigator/src/main/java/com/yapp/navigator/MainActivity.kt
+++ b/feature/navigator/src/main/java/com/yapp/navigator/MainActivity.kt
@@ -5,7 +5,6 @@ import android.content.pm.ActivityInfo
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import com.kms.onboarding.OnboardingRoute
 import com.yapp.designsystem.theme.OrbitTheme
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -17,7 +16,8 @@ class MainActivity : ComponentActivity() {
         requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
         setContent {
             OrbitTheme {
-                OnboardingRoute(onFinishOnboarding = {})
+                MainScreen()
+                //OnboardingRoute(onFinishOnboarding = {})
             }
         }
     }

--- a/feature/navigator/src/main/java/com/yapp/navigator/MainScreen.kt
+++ b/feature/navigator/src/main/java/com/yapp/navigator/MainScreen.kt
@@ -28,7 +28,7 @@ internal fun MainScreen(
                 onClickItem = navigator::navigate,
             )
         },
-        containerColor = OrbitTheme.colors.gray_900
+        containerColor = OrbitTheme.colors.gray_900,
     ) { innerPadding ->
         NavHost(
             navController = navigator.navController,

--- a/feature/navigator/src/main/java/com/yapp/navigator/MainScreen.kt
+++ b/feature/navigator/src/main/java/com/yapp/navigator/MainScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.navigation.compose.NavHost
+import com.yapp.designsystem.theme.OrbitTheme
 import com.yapp.home.homeNavGraph
 import com.yapp.mypage.mypageNavGraph
 import com.yapp.navigator.navigation.MainNavTab
@@ -27,6 +28,7 @@ internal fun MainScreen(
                 onClickItem = navigator::navigate,
             )
         },
+        containerColor = OrbitTheme.colors.gray_900
     ) { innerPadding ->
         NavHost(
             navController = navigator.navController,

--- a/feature/onboarding/src/main/java/com/kms/onboarding/BirthdayScreen.kt
+++ b/feature/onboarding/src/main/java/com/kms/onboarding/BirthdayScreen.kt
@@ -1,5 +1,6 @@
 package com.kms.onboarding
 
+import android.util.Log
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -41,8 +42,10 @@ fun BirthdayScreen(
                 textAlign = TextAlign.Center,
             )
             OrbitYearMonthPicker(
-                modifier = Modifier.padding(top = 60.dp),
-            )
+                modifier = Modifier.padding(top = 60.dp)
+            ) { lunar, year, month, day ->
+                Log.d("BirthdayScreen", "lunar: $lunar, year: $year, month: $month, day: $day")
+            }
         }
     }
 }

--- a/feature/onboarding/src/main/java/com/kms/onboarding/BirthdayScreen.kt
+++ b/feature/onboarding/src/main/java/com/kms/onboarding/BirthdayScreen.kt
@@ -42,7 +42,7 @@ fun BirthdayScreen(
                 textAlign = TextAlign.Center,
             )
             OrbitYearMonthPicker(
-                modifier = Modifier.padding(top = 60.dp)
+                modifier = Modifier.padding(top = 60.dp),
             ) { lunar, year, month, day ->
                 Log.d("BirthdayScreen", "lunar: $lunar, year: $year, month: $month, day: $day")
             }

--- a/feature/onboarding/src/main/java/com/kms/onboarding/OnboardingAlarmTimeSelectionScreen.kt
+++ b/feature/onboarding/src/main/java/com/kms/onboarding/OnboardingAlarmTimeSelectionScreen.kt
@@ -1,5 +1,6 @@
 package com.kms.onboarding
 
+import android.util.Log
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -51,7 +52,9 @@ fun OnboardingAlarmTimeSelectionScreen(
             )
             OrbitPicker(
                 modifier = Modifier.padding(top = 90.dp),
-            )
+            ) { amPm, hour, minute ->
+                Log.d("OnboardingAlarmTimeSelectionScreen", "amPm: $amPm, hour: $hour, minute: $minute")
+            }
         }
     }
 }

--- a/feature/onboarding/src/main/java/com/kms/onboarding/OnboardingBirthdayScreen.kt
+++ b/feature/onboarding/src/main/java/com/kms/onboarding/OnboardingBirthdayScreen.kt
@@ -1,5 +1,6 @@
 package com.kms.onboarding
 
+import android.util.Log
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -43,7 +44,9 @@ fun OnboardingBirthdayScreen(
             )
             OrbitYearMonthPicker(
                 modifier = Modifier.padding(top = 60.dp),
-            )
+            ) { lunar, year, month, day ->
+                Log.d("BirthdayScreen", "lunar: $lunar, year: $year, month: $month, day: $day")
+            }
         }
     }
 }


### PR DESCRIPTION
## Related issue 🛠
[//]: # (해당하는 이슈 번호 달아주기)
closed #20 

어떤 변경사항이 있었나요?
- [ ] 🐞 BugFix Something isn't working
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [x] ✨ Feature Feature
- [ ] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (Junit, etc.)

## CheckPoint ✅
[//]: # (PR 요구사항 확인)
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 컨벤션에 맞게 작성했습니다. (필수)
- [x] merge할 브랜치의 위치를 확인해 주세요(main❌/develop⭕) (필수)
- [x] Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다. (필수)
- [ ] BugFix의 경우, 버그의 원인을 파악하였습니다. (선택)

## Work Description ✏️
[//]: # (작업 내용 간단 소개)
- 기존 OrbitPicker, OrbitYearMonthPicker의 상태 호이스팅이 가능하도록 하였습니다.
```kotlin
OrbitPicker { amPm, hour, minute ->
    Log.d("OrbitPicker", "amPm: $amPm, hour: $hour, minute: $minute")
}

OrbitYearMonthPicker { lunar, year, month, day ->
    Log.d("OrbitYearMonthPicker", "lunar: $lunar, year: $year, month: $month, day: $day")
}
```    
- 알람 설정 화면에 OrbitPicker를 추가했습니다.

![image](https://github.com/user-attachments/assets/aa31362b-69c0-4a27-975e-e023a593e432)


## Uncompleted Tasks 😅
[//]: # (없다면 N/A)
N/A

## To Reviewers 📢
[//]: # (reviewer가 알면 좋은 내용들)