### PR TITLE
[BugFix] OrbitPickerItem 초기화 및 재구성 시 상태 동기화 문제

### DIFF
--- a/core/ui/src/main/java/com/yapp/ui/component/timepicker/OrbitPicker.kt
+++ b/core/ui/src/main/java/com/yapp/ui/component/timepicker/OrbitPicker.kt
@@ -17,6 +17,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -24,6 +25,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.yapp.designsystem.theme.OrbitTheme
+import kotlinx.coroutines.launch
 import java.util.Locale
 
 @Composable
@@ -66,6 +68,8 @@ fun OrbitPicker(
                 selectedItem = selectedMinute.toString(),
                 startIndex = minuteItems.indexOf(initialMinute),
             )
+
+            val scope = rememberCoroutineScope()
 
             Box(modifier = Modifier.fillMaxWidth()) {
                 Box(
@@ -118,6 +122,13 @@ fun OrbitPicker(
                                 minutePickerState,
                                 onValueChange,
                             )
+                        },
+                        onScrollCompleted = {
+                            scope.launch {
+                                val currentIndex = amPmPickerState.lazyListState.firstVisibleItemIndex % amPmItems.size
+                                val nextIndex = (currentIndex + 1) % amPmItems.size
+                                amPmPickerState.lazyListState.animateScrollToItem(nextIndex)
+                            }
                         },
                     )
 

--- a/core/ui/src/main/java/com/yapp/ui/component/timepicker/OrbitPicker.kt
+++ b/core/ui/src/main/java/com/yapp/ui/component/timepicker/OrbitPicker.kt
@@ -1,6 +1,5 @@
 package com.yapp.ui.component.timepicker
 
-import android.util.Log
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -14,7 +13,11 @@ import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
@@ -27,6 +30,12 @@ import java.util.Locale
 fun OrbitPicker(
     modifier: Modifier = Modifier,
     itemSpacing: Dp = 2.dp,
+    initialAmPm: String = "오전",
+    initialHour: String = "1",
+    initialMinute: String = "00",
+    selectedAmPm: String,
+    selectedHour: Int,
+    selectedMinute: Int,
     onValueChange: (String, Int, Int) -> Unit,
 ) {
     Surface(
@@ -45,9 +54,18 @@ fun OrbitPicker(
             val hourItems = remember { (1..12).map { it.toString() } }
             val minuteItems = remember { (0..59).map { String.format(Locale.ROOT, "%02d", it) } }
 
-            val amPmPickerState = rememberPickerState()
-            val hourPickerState = rememberPickerState()
-            val minutePickerState = rememberPickerState()
+            val amPmPickerState = rememberPickerState(
+                selectedItem = selectedAmPm,
+                startIndex = amPmItems.indexOf(initialAmPm),
+            )
+            val hourPickerState = rememberPickerState(
+                selectedItem = selectedHour.toString(),
+                startIndex = hourItems.indexOf(initialHour),
+            )
+            val minutePickerState = rememberPickerState(
+                selectedItem = selectedMinute.toString(),
+                startIndex = minuteItems.indexOf(initialMinute),
+            )
 
             Box(modifier = Modifier.fillMaxWidth()) {
                 Box(
@@ -142,7 +160,17 @@ private fun onPickerValueChange(
 @Preview(showBackground = true)
 @Composable
 fun BottomSheetPickerPreview() {
-    OrbitPicker { amPm, hour, minute ->
-        Log.d("OrbitPicker", "amPm: $amPm, hour: $hour, minute: $minute")
+    var selectedAmPm by remember { mutableStateOf("오전") }
+    var selectedHour by remember { mutableIntStateOf(6) }
+    var selectedMinute by remember { mutableIntStateOf(0) }
+
+    OrbitPicker(
+        selectedAmPm = selectedAmPm,
+        selectedHour = selectedHour,
+        selectedMinute = selectedMinute,
+    ) { amPm, hour, minute ->
+        selectedAmPm = amPm
+        selectedHour = hour
+        selectedMinute = minute
     }
 }

--- a/core/ui/src/main/java/com/yapp/ui/component/timepicker/OrbitPickerItem.kt
+++ b/core/ui/src/main/java/com/yapp/ui/component/timepicker/OrbitPickerItem.kt
@@ -130,13 +130,12 @@ fun OrbitPickerItem(
                 }
 
                 val scaleY = 1f - (0.4f * (distanceFromCenter / maxDistance)).coerceIn(0f, 0.4f)
-                val isSelected = getItemForIndex(index, items, infiniteScroll, visibleItemsMiddle) == state.selectedItem
 
                 Text(
                     text = getItemForIndex(index, items, infiniteScroll, visibleItemsMiddle),
                     maxLines = 1,
                     style = textStyle,
-                    color = if (isSelected) OrbitTheme.colors.white else OrbitTheme.colors.white.copy(alpha = alpha),
+                    color = OrbitTheme.colors.white.copy(alpha = alpha),
                     modifier = Modifier
                         .padding(vertical = itemSpacing / 2)
                         .graphicsLayer(scaleY = scaleY)

--- a/core/ui/src/main/java/com/yapp/ui/component/timepicker/OrbitYearMonthPicker.kt
+++ b/core/ui/src/main/java/com/yapp/ui/component/timepicker/OrbitYearMonthPicker.kt
@@ -1,6 +1,5 @@
 package com.yapp.ui.component.timepicker
 
-import android.util.Log
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -15,7 +14,11 @@ import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalConfiguration
@@ -29,6 +32,14 @@ import java.util.Locale
 fun OrbitYearMonthPicker(
     modifier: Modifier = Modifier,
     itemSpacing: Dp = 12.dp,
+    initialLunar: String = "음력",
+    initialYear: String = "1900",
+    initialMonth: String = "1",
+    initialDay: String = "01",
+    selectedLunar: String,
+    selectedYear: Int,
+    selectedMonth: Int,
+    selectedDay: Int,
     onValueChange: (String, Int, Int, Int) -> Unit,
 ) {
     val screenWidth = LocalConfiguration.current.screenWidthDp.dp
@@ -50,10 +61,22 @@ fun OrbitYearMonthPicker(
             val monthItems = remember { (1..12).map { it.toString() } }
             val dayItems = remember { (1..31).map { String.format(Locale.ROOT, "%02d", it) } }
 
-            val lunarPickerState = rememberPickerState()
-            val yearPickerState = rememberPickerState()
-            val monthPickerState = rememberPickerState()
-            val dayPickerState = rememberPickerState()
+            val lunarPickerState = rememberPickerState(
+                selectedItem = selectedLunar,
+                startIndex = lunarItems.indexOf(initialLunar),
+            )
+            val yearPickerState = rememberPickerState(
+                selectedItem = selectedYear.toString(),
+                startIndex = yearItems.indexOf(initialYear),
+            )
+            val monthPickerState = rememberPickerState(
+                selectedItem = selectedMonth.toString(),
+                startIndex = monthItems.indexOf(initialMonth),
+            )
+            val dayPickerState = rememberPickerState(
+                selectedItem = selectedDay.toString(),
+                startIndex = dayItems.indexOf(initialDay),
+            )
 
             Box(
                 modifier = Modifier.fillMaxWidth(),
@@ -89,7 +112,6 @@ fun OrbitYearMonthPicker(
                         state = yearPickerState,
                         items = yearItems,
                         visibleItemsCount = 5,
-                        startIndex = 90,
                         itemSpacing = itemSpacing,
                         textStyle = OrbitTheme.typography.title2SemiBold,
                         modifier = Modifier.width(screenWidth * 0.25f),
@@ -143,7 +165,20 @@ private fun onPickerValueChange(
 @Preview(showBackground = true)
 @Composable
 fun OrbitYearMonthPickerPreview() {
-    OrbitYearMonthPicker { lunar, year, month, day ->
-        Log.d("OrbitYearMonthPicker", "lunar: $lunar, year: $year, month: $month, day: $day")
+    var selectedLunar by remember { mutableStateOf("음력") }
+    var selectedYear by remember { mutableIntStateOf(1900) }
+    var selectedMonth by remember { mutableIntStateOf(1) }
+    var selectedDay by remember { mutableIntStateOf(1) }
+
+    OrbitYearMonthPicker(
+        selectedLunar = selectedLunar,
+        selectedYear = selectedYear,
+        selectedMonth = selectedMonth,
+        selectedDay = selectedDay,
+    ) { lunar, year, month, day ->
+        selectedLunar = lunar
+        selectedYear = year
+        selectedMonth = month
+        selectedDay = day
     }
 }

--- a/core/ui/src/main/java/com/yapp/ui/component/timepicker/PickerState.kt
+++ b/core/ui/src/main/java/com/yapp/ui/component/timepicker/PickerState.kt
@@ -1,16 +1,20 @@
 package com.yapp.ui.component.timepicker
 
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.Stable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 
-@Stable
-class PickerState {
-    var selectedItem: String by mutableStateOf("")
-}
+class PickerState(
+    val lazyListState: LazyListState,
+    var selectedItem: String,
+    var startIndex: Int,
+    var initialized: Boolean = false,
+)
 
 @Composable
-fun rememberPickerState() = remember { PickerState() }
+fun rememberPickerState(
+    lazyListState: LazyListState = rememberLazyListState(),
+    selectedItem: String = "",
+    startIndex: Int = 0,
+): PickerState = remember { PickerState(lazyListState, selectedItem, startIndex) }

--- a/feature/home/src/main/java/com/yapp/alarm/AlarmAddEditScreen.kt
+++ b/feature/home/src/main/java/com/yapp/alarm/AlarmAddEditScreen.kt
@@ -1,6 +1,5 @@
 package com.yapp.alarm
 
-import android.util.Log
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -12,6 +11,11 @@ import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
@@ -27,6 +31,10 @@ fun AlarmAddEditRoute() {
 
 @Composable
 fun AlarmAddEditScreen() {
+    var selectedAmPm by remember { mutableStateOf("오전") }
+    var selectedHour by remember { mutableIntStateOf(1) }
+    var selectedMinute by remember { mutableIntStateOf(0) }
+
     Column(
         modifier = Modifier.fillMaxSize(),
         horizontalAlignment = Alignment.CenterHorizontally,
@@ -37,8 +45,13 @@ fun AlarmAddEditScreen() {
         )
         OrbitPicker(
             modifier = Modifier.padding(top = 40.dp),
+            selectedAmPm = selectedAmPm,
+            selectedHour = selectedHour,
+            selectedMinute = selectedMinute,
         ) { amPm, hour, minute ->
-            Log.d("AlarmAddEditScreen", "amPm: $amPm, hour: $hour, minute: $minute")
+            selectedAmPm = amPm
+            selectedHour = hour
+            selectedMinute = minute
         }
     }
 }

--- a/feature/onboarding/src/main/java/com/kms/onboarding/BirthdayScreen.kt
+++ b/feature/onboarding/src/main/java/com/kms/onboarding/BirthdayScreen.kt
@@ -1,6 +1,5 @@
 package com.kms.onboarding
 
-import android.util.Log
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -8,6 +7,11 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
@@ -25,6 +29,11 @@ fun BirthdayScreen(
     onNextClick: () -> Unit,
     onBackClick: () -> Unit,
 ) {
+    var selectedLunar by remember { mutableStateOf("음력") }
+    var selectedYear by remember { mutableIntStateOf(1900) }
+    var selectedMonth by remember { mutableIntStateOf(1) }
+    var selectedDay by remember { mutableIntStateOf(1) }
+
     OnboardingScreen(
         currentStep = currentStep,
         totalSteps = totalSteps,
@@ -43,8 +52,15 @@ fun BirthdayScreen(
             )
             OrbitYearMonthPicker(
                 modifier = Modifier.padding(top = 60.dp),
+                selectedLunar = selectedLunar,
+                selectedYear = selectedYear,
+                selectedMonth = selectedMonth,
+                selectedDay = selectedDay,
             ) { lunar, year, month, day ->
-                Log.d("BirthdayScreen", "lunar: $lunar, year: $year, month: $month, day: $day")
+                selectedLunar = lunar
+                selectedYear = year
+                selectedMonth = month
+                selectedDay = day
             }
         }
     }

--- a/feature/onboarding/src/main/java/com/kms/onboarding/OnboardingAlarmTimeSelectionScreen.kt
+++ b/feature/onboarding/src/main/java/com/kms/onboarding/OnboardingAlarmTimeSelectionScreen.kt
@@ -1,6 +1,5 @@
 package com.kms.onboarding
 
-import android.util.Log
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -8,6 +7,11 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
@@ -25,6 +29,10 @@ fun OnboardingAlarmTimeSelectionScreen(
     onNextClick: () -> Unit,
     onBackClick: () -> Unit,
 ) {
+    var selectedAmPm by remember { mutableStateOf("오전") }
+    var selectedHour by remember { mutableIntStateOf(1) }
+    var selectedMinute by remember { mutableIntStateOf(0) }
+
     OnboardingScreen(
         currentStep = currentStep,
         totalSteps = totalSteps,
@@ -52,8 +60,13 @@ fun OnboardingAlarmTimeSelectionScreen(
             )
             OrbitPicker(
                 modifier = Modifier.padding(top = 90.dp),
+                selectedAmPm = selectedAmPm,
+                selectedHour = selectedHour,
+                selectedMinute = selectedMinute,
             ) { amPm, hour, minute ->
-                Log.d("OnboardingAlarmTimeSelectionScreen", "amPm: $amPm, hour: $hour, minute: $minute")
+                selectedAmPm = amPm
+                selectedHour = hour
+                selectedMinute = minute
             }
         }
     }

--- a/feature/onboarding/src/main/java/com/kms/onboarding/OnboardingBirthdayScreen.kt
+++ b/feature/onboarding/src/main/java/com/kms/onboarding/OnboardingBirthdayScreen.kt
@@ -1,6 +1,5 @@
 package com.kms.onboarding
 
-import android.util.Log
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -8,6 +7,11 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
@@ -26,6 +30,11 @@ fun OnboardingBirthdayScreen(
     onNextClick: () -> Unit,
     onBackClick: () -> Unit,
 ) {
+    var selectedLunar by remember { mutableStateOf("음력") }
+    var selectedYear by remember { mutableIntStateOf(1900) }
+    var selectedMonth by remember { mutableIntStateOf(1) }
+    var selectedDay by remember { mutableIntStateOf(1) }
+
     OnboardingScreen(
         currentStep = currentStep,
         totalSteps = totalSteps,
@@ -44,8 +53,15 @@ fun OnboardingBirthdayScreen(
             )
             OrbitYearMonthPicker(
                 modifier = Modifier.padding(top = 60.dp),
+                selectedLunar = selectedLunar,
+                selectedYear = selectedYear,
+                selectedMonth = selectedMonth,
+                selectedDay = selectedDay,
             ) { lunar, year, month, day ->
-                Log.d("BirthdayScreen", "lunar: $lunar, year: $year, month: $month, day: $day")
+                selectedLunar = lunar
+                selectedYear = year
+                selectedMonth = month
+                selectedDay = day
             }
         }
     }


### PR DESCRIPTION
## Related issue 🛠
[//]: # (해당하는 이슈 번호 달아주기)
closed #35 

어떤 변경사항이 있었나요?
- [x] 🐞 BugFix Something isn't working
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [] ✨ Feature Feature
- [ ] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (Junit, etc.)

## CheckPoint ✅
[//]: # (PR 요구사항 확인)
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 컨벤션에 맞게 작성했습니다. (필수)
- [x] merge할 브랜치의 위치를 확인해 주세요(main❌/develop⭕) (필수)
- [x] Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다. (필수)
- [x] BugFix의 경우, 버그의 원인을 파악하였습니다. (선택)

## Work Description ✏️
[//]: # (작업 내용 간단 소개)

https://github.com/user-attachments/assets/1c49bf1a-6103-4e27-918e-75c7abeca6d6

해당 2가지 문제가 있었습니다.

1. LazyListState의 초기화 로직이 재구성 시 여러 번 실행되며, 예상치 못한 스크롤 동작을 유발.
2. selectedItem 값이 재구성 이후에도 부모와 불일치하여 상태 꼬임 발생.

이를 해결하기 위해 다음 방안을 적용하였습니다.
 
1. PickerState를 통해 LazyListState, startIndex, selectedItem을 묶어서 관리
2. rememberPickerState를 활용하여 LazyListState와 startIndex의 초기화 로직이 Recomposition 시 여러 번 실행되지 않도록 제어

또한, onScrollCompleted()를 통해 PickerItem의 값들이 한바퀴 이상 순환할 경우 호출할 메소드를 넣을 수 있도록 하였습니다.

```kotlin
if ((previousAdjustedIndex == 0 && adjustedIndex == lastIndex) || 
    (previousAdjustedIndex == lastIndex && adjustedIndex == 0)) {
    onScrollCompleted()
}
```

해당 변경사항을 통해 hour이 한바퀴 이상 순환할 경우 AM/PM이 토글되도록 하였습니다.

## Uncompleted Tasks 😅
[//]: # (없다면 N/A)
N/A

## To Reviewers 📢
[//]: # (reviewer가 알면 좋은 내용들)
행복해요