### PR TITLE
[BugFix] OrbitPickerItem 초기화 및 재구성 시 상태 동기화 문제

### DIFF
--- a/core/ui/src/main/java/com/yapp/ui/component/timepicker/OrbitPicker.kt
+++ b/core/ui/src/main/java/com/yapp/ui/component/timepicker/OrbitPicker.kt
@@ -1,6 +1,5 @@
 package com.yapp.ui.component.timepicker
 
-import android.util.Log
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -11,31 +10,32 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.layout.wrapContentSize
-import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.yapp.designsystem.theme.OrbitTheme
-import kotlinx.coroutines.launch
 import java.util.Locale
 
 @Composable
 fun OrbitPicker(
     modifier: Modifier = Modifier,
     itemSpacing: Dp = 2.dp,
-    selectedAmPm: String = "오후",
-    selectedHour: Int = 0,
-    selectedMinute: Int = 0,
-    amPmStartIndex: Int = 0,
-    hourStartIndex: Int = 5,
-    minuteStartIndex: Int = 0,
+    initialAmPm: String = "오전",
+    initialHour: String = "1",
+    initialMinute: String = "00",
+    selectedAmPm: String,
+    selectedHour: Int,
+    selectedMinute: Int,
     onValueChange: (String, Int, Int) -> Unit,
 ) {
     Surface(
@@ -54,11 +54,18 @@ fun OrbitPicker(
             val hourItems = remember { (1..12).map { it.toString() } }
             val minuteItems = remember { (0..59).map { String.format(Locale.ROOT, "%02d", it) } }
 
-            val amPmListState = rememberLazyListState()
-            val hourListState = rememberLazyListState()
-            val minuteListState = rememberLazyListState()
-
-            val scope = rememberCoroutineScope()
+            val amPmPickerState = rememberPickerState(
+                selectedItem = selectedAmPm,
+                startIndex = amPmItems.indexOf(initialAmPm),
+            )
+            val hourPickerState = rememberPickerState(
+                selectedItem = selectedHour.toString(),
+                startIndex = hourItems.indexOf(initialHour),
+            )
+            val minutePickerState = rememberPickerState(
+                selectedItem = selectedMinute.toString(),
+                startIndex = minuteItems.indexOf(initialMinute),
+            )
 
             Box(modifier = Modifier.fillMaxWidth()) {
                 Box(
@@ -77,57 +84,59 @@ fun OrbitPicker(
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
                     OrbitPickerItem(
+                        state = amPmPickerState,
                         items = amPmItems,
-                        listState = amPmListState,
                         visibleItemsCount = 3,
                         itemSpacing = itemSpacing,
                         textStyle = OrbitTheme.typography.title2Medium,
                         modifier = Modifier.weight(1f),
                         textModifier = Modifier.padding(8.dp),
-                        startIndex = amPmStartIndex,
                         infiniteScroll = false,
-                        selectedItem = selectedAmPm,
-                        onSelectedItemChange = { amPm ->
-                            onValueChange(amPm, selectedHour, selectedMinute)
+                        onValueChange = {
+                            onPickerValueChange(
+                                amPmPickerState,
+                                hourPickerState,
+                                minutePickerState,
+                                onValueChange,
+                            )
                         },
                     )
 
                     OrbitPickerItem(
+                        state = hourPickerState,
                         items = hourItems,
-                        listState = hourListState,
                         visibleItemsCount = 5,
                         itemSpacing = itemSpacing,
                         textStyle = OrbitTheme.typography.title2Medium,
                         modifier = Modifier.weight(1f),
                         textModifier = Modifier.padding(8.dp),
-                        startIndex = hourStartIndex,
                         infiniteScroll = true,
-                        selectedItem = selectedHour.toString(),
-                        onSelectedItemChange = { hour ->
-                            onValueChange(selectedAmPm, hour.toInt(), selectedMinute)
-                        },
-                        onScrollCompleted = {
-                            scope.launch {
-                                val currentIndex = amPmListState.firstVisibleItemIndex % amPmItems.size
-                                val nextIndex = (currentIndex + 1) % amPmItems.size
-                                amPmListState.animateScrollToItem(nextIndex)
-                            }
+                        onValueChange = {
+                            onPickerValueChange(
+                                amPmPickerState,
+                                hourPickerState,
+                                minutePickerState,
+                                onValueChange,
+                            )
                         },
                     )
 
                     OrbitPickerItem(
+                        state = minutePickerState,
                         items = minuteItems,
-                        listState = minuteListState,
                         visibleItemsCount = 5,
                         itemSpacing = itemSpacing,
                         textStyle = OrbitTheme.typography.title2Medium,
                         modifier = Modifier.weight(1f),
                         textModifier = Modifier.padding(8.dp),
-                        startIndex = minuteStartIndex,
                         infiniteScroll = true,
-                        selectedItem = selectedMinute.toString(),
-                        onSelectedItemChange = { minute ->
-                            onValueChange(selectedAmPm, selectedHour, minute.toInt())
+                        onValueChange = {
+                            onPickerValueChange(
+                                amPmPickerState,
+                                hourPickerState,
+                                minutePickerState,
+                                onValueChange,
+                            )
                         },
                     )
                 }
@@ -136,10 +145,32 @@ fun OrbitPicker(
     }
 }
 
+private fun onPickerValueChange(
+    amPmState: PickerState,
+    hourState: PickerState,
+    minuteState: PickerState,
+    onValueChange: (String, Int, Int) -> Unit,
+) {
+    val amPm = amPmState.selectedItem
+    val hour = hourState.selectedItem.toIntOrNull() ?: 0
+    val minute = minuteState.selectedItem.toIntOrNull() ?: 0
+    onValueChange(amPm, hour, minute)
+}
+
 @Preview(showBackground = true)
 @Composable
 fun BottomSheetPickerPreview() {
-    OrbitPicker { amPm, hour, minute ->
-        Log.d("OrbitPicker", "amPm: $amPm, hour: $hour, minute: $minute")
+    var selectedAmPm by remember { mutableStateOf("오전") }
+    var selectedHour by remember { mutableIntStateOf(6) }
+    var selectedMinute by remember { mutableIntStateOf(0) }
+
+    OrbitPicker(
+        selectedAmPm = selectedAmPm,
+        selectedHour = selectedHour,
+        selectedMinute = selectedMinute,
+    ) { amPm, hour, minute ->
+        selectedAmPm = amPm
+        selectedHour = hour
+        selectedMinute = minute
     }
 }

--- a/core/ui/src/main/java/com/yapp/ui/component/timepicker/OrbitPicker.kt
+++ b/core/ui/src/main/java/com/yapp/ui/component/timepicker/OrbitPicker.kt
@@ -1,5 +1,6 @@
 package com.yapp.ui.component.timepicker
 
+import android.util.Log
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -13,12 +14,8 @@ import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
@@ -35,9 +32,6 @@ fun OrbitPicker(
     initialAmPm: String = "오전",
     initialHour: String = "1",
     initialMinute: String = "00",
-    selectedAmPm: String,
-    selectedHour: Int,
-    selectedMinute: Int,
     onValueChange: (String, Int, Int) -> Unit,
 ) {
     Surface(
@@ -57,15 +51,15 @@ fun OrbitPicker(
             val minuteItems = remember { (0..59).map { String.format(Locale.ROOT, "%02d", it) } }
 
             val amPmPickerState = rememberPickerState(
-                selectedItem = selectedAmPm,
+                selectedItem = amPmItems.indexOf(initialAmPm).toString(),
                 startIndex = amPmItems.indexOf(initialAmPm),
             )
             val hourPickerState = rememberPickerState(
-                selectedItem = selectedHour.toString(),
+                selectedItem = hourItems.indexOf(initialHour).toString(),
                 startIndex = hourItems.indexOf(initialHour),
             )
             val minutePickerState = rememberPickerState(
-                selectedItem = selectedMinute.toString(),
+                selectedItem = minuteItems.indexOf(initialMinute).toString(),
                 startIndex = minuteItems.indexOf(initialMinute),
             )
 
@@ -170,18 +164,8 @@ private fun onPickerValueChange(
 
 @Preview(showBackground = true)
 @Composable
-fun BottomSheetPickerPreview() {
-    var selectedAmPm by remember { mutableStateOf("오전") }
-    var selectedHour by remember { mutableIntStateOf(6) }
-    var selectedMinute by remember { mutableIntStateOf(0) }
-
-    OrbitPicker(
-        selectedAmPm = selectedAmPm,
-        selectedHour = selectedHour,
-        selectedMinute = selectedMinute,
-    ) { amPm, hour, minute ->
-        selectedAmPm = amPm
-        selectedHour = hour
-        selectedMinute = minute
+fun OrbitPickerPreview() {
+    OrbitPicker { amPm, hour, minute ->
+        Log.d("OrbitPicker", "selectedAmPm: $amPm, selectedHour: $hour, selectedMinute: $minute")
     }
 }

--- a/core/ui/src/main/java/com/yapp/ui/component/timepicker/OrbitPicker.kt
+++ b/core/ui/src/main/java/com/yapp/ui/component/timepicker/OrbitPicker.kt
@@ -17,6 +17,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -24,6 +25,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.yapp.designsystem.theme.OrbitTheme
+import kotlinx.coroutines.launch
 import java.util.Locale
 
 @Composable
@@ -66,6 +68,8 @@ fun OrbitPicker(
                 selectedItem = selectedMinute.toString(),
                 startIndex = minuteItems.indexOf(initialMinute),
             )
+
+            val scope = rememberCoroutineScope()
 
             Box(modifier = Modifier.fillMaxWidth()) {
                 Box(
@@ -118,6 +122,13 @@ fun OrbitPicker(
                                 minutePickerState,
                                 onValueChange,
                             )
+                        },
+                        onScrollCompleted = {
+                            scope.launch {
+                                val currentIndex = amPmPickerState.lazyListState.firstVisibleItemIndex % amPmItems.size
+                                val nextIndex = (currentIndex + 1) % amPmItems.size
+                                amPmPickerState.lazyListState.animateScrollToItem(nextIndex)
+                            }
                         },
                     )
 

--- a/core/ui/src/main/java/com/yapp/ui/component/timepicker/OrbitPickerItem.kt
+++ b/core/ui/src/main/java/com/yapp/ui/component/timepicker/OrbitPickerItem.kt
@@ -7,16 +7,11 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.LazyListState
-import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -31,63 +26,63 @@ import androidx.compose.ui.unit.dp
 import com.yapp.designsystem.theme.OrbitTheme
 import com.yapp.ui.utils.toPx
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
 import kotlin.math.abs
 
 @Composable
 fun OrbitPickerItem(
     modifier: Modifier = Modifier,
     items: List<String>,
-    selectedItem: String,
-    onSelectedItemChange: (String) -> Unit,
-    onScrollCompleted: (() -> Unit)? = null,
-    listState: LazyListState = rememberLazyListState(),
-    startIndex: Int = 0,
+    state: PickerState = rememberPickerState(),
     visibleItemsCount: Int,
     textModifier: Modifier = Modifier,
     infiniteScroll: Boolean = true,
     textStyle: TextStyle,
     itemSpacing: Dp,
+    onValueChange: (String) -> Unit,
 ) {
     val visibleItemsMiddle = visibleItemsCount / 2
     val listScrollCount = if (infiniteScroll) Int.MAX_VALUE else items.size + visibleItemsMiddle * 2
     val listScrollMiddle = listScrollCount / 2
-    val listStartIndex = calculateStartIndex(
-        infiniteScroll,
-        items.size,
-        listScrollMiddle,
-        visibleItemsMiddle,
-        startIndex,
-    )
+
+    val listState = state.lazyListState
     val flingBehavior = rememberSnapFlingBehavior(lazyListState = listState)
     val itemHeightPixels = remember { mutableIntStateOf(0) }
     val itemHeightDp = with(LocalDensity.current) { itemHeightPixels.intValue.toDp() }
 
-    LaunchedEffect(listState) {
-        if (listState.firstVisibleItemIndex != listStartIndex) {
-            listState.scrollToItem(listStartIndex) // 초기 스크롤 위치 설정
+    LaunchedEffect(key1 = state.initialized) {
+        if (!state.initialized) {
+            val listStartIndex = calculateStartIndex(
+                infiniteScroll,
+                items.size,
+                listScrollMiddle,
+                visibleItemsMiddle,
+                state.startIndex,
+            )
+            listState.scrollToItem(listStartIndex)
+            state.initialized = true
         }
     }
 
     LaunchedEffect(listState) {
-        var previousAdjustedIndex = calculateCenterIndex(listState) // 초기값 설정
-
-        snapshotFlow { calculateCenterIndex(listState) }
+        snapshotFlow { listState.layoutInfo }
+            .map { layoutInfo ->
+                val centerOffset = layoutInfo.viewportStartOffset + (layoutInfo.viewportEndOffset - layoutInfo.viewportStartOffset) / 2
+                layoutInfo.visibleItemsInfo.minByOrNull { item ->
+                    val itemCenter = item.offset + (item.size / 2)
+                    abs(itemCenter - centerOffset)
+                }?.index
+            }
             .distinctUntilChanged()
             .collect { centerIndex ->
-                val adjustedIndex = centerIndex % items.size
-
-                // 끝에서 끝으로 이동 감지
-                if (previousAdjustedIndex == items.size - 1 && adjustedIndex == 0) {
-                    onScrollCompleted?.invoke()
-                } else if (previousAdjustedIndex == 0 && adjustedIndex == items.size - 1) {
-                    onScrollCompleted?.invoke()
+                if (centerIndex != null) {
+                    val adjustedIndex = centerIndex % items.size
+                    val newValue = items[adjustedIndex]
+                    if (newValue != state.selectedItem) {
+                        state.selectedItem = newValue
+                        onValueChange(newValue)
+                    }
                 }
-
-                if (adjustedIndex != previousAdjustedIndex) {
-                    onSelectedItemChange(items[adjustedIndex])
-                }
-
-                previousAdjustedIndex = adjustedIndex
             }
     }
 
@@ -113,9 +108,15 @@ fun OrbitPickerItem(
 
                 val distanceFromCenter = abs(viewportCenterOffset - itemCenterOffset)
                 val maxDistance = totalItemHeight.toPx() * visibleItemsMiddle
-                val alpha = ((maxDistance - distanceFromCenter) / maxDistance).coerceIn(0.2f, 1f)
+
+                val alpha = if (distanceFromCenter <= maxDistance) {
+                    ((maxDistance - distanceFromCenter) / maxDistance).coerceIn(0.2f, 1f)
+                } else {
+                    0.2f
+                }
+
                 val scaleY = 1f - (0.4f * (distanceFromCenter / maxDistance)).coerceIn(0f, 0.4f)
-                val isSelected = getItemForIndex(index, items, infiniteScroll, visibleItemsMiddle) == selectedItem
+                val isSelected = getItemForIndex(index, items, infiniteScroll, visibleItemsMiddle) == state.selectedItem
 
                 Text(
                     text = getItemForIndex(index, items, infiniteScroll, visibleItemsMiddle),
@@ -151,19 +152,6 @@ private fun calculateStartIndex(
 }
 
 /**
- * 중심 인덱스를 계산합니다.
- */
-private fun calculateCenterIndex(listState: LazyListState): Int {
-    val layoutInfo = listState.layoutInfo
-    val centerOffset = layoutInfo.viewportStartOffset + (layoutInfo.viewportEndOffset - layoutInfo.viewportStartOffset) / 2
-
-    return layoutInfo.visibleItemsInfo.minByOrNull { item ->
-        val itemCenter = item.offset + (item.size / 2)
-        abs(itemCenter - centerOffset)
-    }?.index ?: 0
-}
-
-/**
  * 주어진 인덱스에 해당하는 항목을 반환합니다.
  * 무한 스크롤과 보이는 항목의 개수를 고려합니다.
  */
@@ -179,15 +167,13 @@ private fun getItemForIndex(index: Int, items: List<String>, infiniteScroll: Boo
 @Preview
 fun OrbitPickerPreview() {
     OrbitTheme {
-        var selectedItem by remember { mutableStateOf("0") }
-
         OrbitPickerItem(
             items = (0..100).map { it.toString() },
-            selectedItem = selectedItem,
-            onSelectedItemChange = { selectedItem = it },
+            state = rememberPickerState(),
             visibleItemsCount = 5,
             textStyle = TextStyle.Default,
             itemSpacing = 8.dp,
+            onValueChange = {},
         )
     }
 }

--- a/core/ui/src/main/java/com/yapp/ui/component/timepicker/OrbitPickerItem.kt
+++ b/core/ui/src/main/java/com/yapp/ui/component/timepicker/OrbitPickerItem.kt
@@ -178,7 +178,7 @@ private fun getItemForIndex(index: Int, items: List<String>, infiniteScroll: Boo
 
 @Composable
 @Preview
-fun OrbitPickerPreview() {
+fun OrbitPickerItemPreview() {
     OrbitTheme {
         OrbitPickerItem(
             items = (0..100).map { it.toString() },

--- a/core/ui/src/main/java/com/yapp/ui/component/timepicker/OrbitPickerItem.kt
+++ b/core/ui/src/main/java/com/yapp/ui/component/timepicker/OrbitPickerItem.kt
@@ -130,13 +130,12 @@ fun OrbitPickerItem(
                 }
 
                 val scaleY = 1f - (0.4f * (distanceFromCenter / maxDistance)).coerceIn(0f, 0.4f)
-                val isSelected = getItemForIndex(index, items, infiniteScroll, visibleItemsMiddle) == state.selectedItem
 
                 Text(
                     text = getItemForIndex(index, items, infiniteScroll, visibleItemsMiddle),
                     maxLines = 1,
                     style = textStyle,
-                    color = if (isSelected) OrbitTheme.colors.white else OrbitTheme.colors.white.copy(alpha = alpha),
+                    color = OrbitTheme.colors.white.copy(alpha = alpha),
                     modifier = Modifier
                         .padding(vertical = itemSpacing / 2)
                         .graphicsLayer(scaleY = scaleY)

--- a/core/ui/src/main/java/com/yapp/ui/component/timepicker/OrbitYearMonthPicker.kt
+++ b/core/ui/src/main/java/com/yapp/ui/component/timepicker/OrbitYearMonthPicker.kt
@@ -1,5 +1,6 @@
 package com.yapp.ui.component.timepicker
 
+import android.util.Log
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -14,11 +15,7 @@ import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalConfiguration
@@ -36,10 +33,6 @@ fun OrbitYearMonthPicker(
     initialYear: String = "1900",
     initialMonth: String = "1",
     initialDay: String = "01",
-    selectedLunar: String,
-    selectedYear: Int,
-    selectedMonth: Int,
-    selectedDay: Int,
     onValueChange: (String, Int, Int, Int) -> Unit,
 ) {
     val screenWidth = LocalConfiguration.current.screenWidthDp.dp
@@ -62,19 +55,19 @@ fun OrbitYearMonthPicker(
             val dayItems = remember { (1..31).map { String.format(Locale.ROOT, "%02d", it) } }
 
             val lunarPickerState = rememberPickerState(
-                selectedItem = selectedLunar,
+                selectedItem = lunarItems.indexOf(initialLunar).toString(),
                 startIndex = lunarItems.indexOf(initialLunar),
             )
             val yearPickerState = rememberPickerState(
-                selectedItem = selectedYear.toString(),
+                selectedItem = yearItems.indexOf(initialYear).toString(),
                 startIndex = yearItems.indexOf(initialYear),
             )
             val monthPickerState = rememberPickerState(
-                selectedItem = selectedMonth.toString(),
+                selectedItem = monthItems.indexOf(initialMonth).toString(),
                 startIndex = monthItems.indexOf(initialMonth),
             )
             val dayPickerState = rememberPickerState(
-                selectedItem = selectedDay.toString(),
+                selectedItem = dayItems.indexOf(initialDay).toString(),
                 startIndex = dayItems.indexOf(initialDay),
             )
 
@@ -165,20 +158,7 @@ private fun onPickerValueChange(
 @Preview(showBackground = true)
 @Composable
 fun OrbitYearMonthPickerPreview() {
-    var selectedLunar by remember { mutableStateOf("음력") }
-    var selectedYear by remember { mutableIntStateOf(1900) }
-    var selectedMonth by remember { mutableIntStateOf(1) }
-    var selectedDay by remember { mutableIntStateOf(1) }
-
-    OrbitYearMonthPicker(
-        selectedLunar = selectedLunar,
-        selectedYear = selectedYear,
-        selectedMonth = selectedMonth,
-        selectedDay = selectedDay,
-    ) { lunar, year, month, day ->
-        selectedLunar = lunar
-        selectedYear = year
-        selectedMonth = month
-        selectedDay = day
+    OrbitYearMonthPicker { lunar, year, month, day ->
+        Log.d("OrbitYearMonthPickerPreview", "lunar: $lunar, year: $year, month: $month, day: $day")
     }
 }

--- a/core/ui/src/main/java/com/yapp/ui/component/timepicker/PickerState.kt
+++ b/core/ui/src/main/java/com/yapp/ui/component/timepicker/PickerState.kt
@@ -1,16 +1,20 @@
 package com.yapp.ui.component.timepicker
 
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.Stable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 
-@Stable
-class PickerState {
-    var selectedItem: String by mutableStateOf("")
-}
+class PickerState(
+    val lazyListState: LazyListState,
+    var selectedItem: String,
+    var startIndex: Int,
+    var initialized: Boolean = false,
+)
 
 @Composable
-fun rememberPickerState() = remember { PickerState() }
+fun rememberPickerState(
+    lazyListState: LazyListState = rememberLazyListState(),
+    selectedItem: String = "",
+    startIndex: Int = 0,
+): PickerState = remember { PickerState(lazyListState, selectedItem, startIndex) }

--- a/feature/home/src/main/java/com/yapp/alarm/AlarmAddEditScreen.kt
+++ b/feature/home/src/main/java/com/yapp/alarm/AlarmAddEditScreen.kt
@@ -1,19 +1,14 @@
 package com.yapp.alarm
 
-import androidx.compose.foundation.background
+import android.util.Log
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -21,19 +16,13 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.yapp.alarm.component.AlarmCheckItem
-import com.yapp.alarm.component.AlarmDayButton
 import com.yapp.designsystem.theme.OrbitTheme
-import com.yapp.ui.component.button.OrbitButton
-import com.yapp.ui.component.switch.OrbitSwitch
 import com.yapp.ui.component.timepicker.OrbitPicker
 import com.yapp.ui.lifecycle.LaunchedEffectWithLifecycle
-import feature.home.R
 
 @Composable
 fun AlarmAddEditRoute(

--- a/feature/home/src/main/java/com/yapp/alarm/AlarmAddEditScreen.kt
+++ b/feature/home/src/main/java/com/yapp/alarm/AlarmAddEditScreen.kt
@@ -1,14 +1,19 @@
 package com.yapp.alarm
 
-import android.util.Log
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -16,13 +21,19 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.yapp.alarm.component.AlarmCheckItem
+import com.yapp.alarm.component.AlarmDayButton
 import com.yapp.designsystem.theme.OrbitTheme
+import com.yapp.ui.component.button.OrbitButton
+import com.yapp.ui.component.switch.OrbitSwitch
 import com.yapp.ui.component.timepicker.OrbitPicker
 import com.yapp.ui.lifecycle.LaunchedEffectWithLifecycle
+import feature.home.R
 
 @Composable
 fun AlarmAddEditRoute(
@@ -68,11 +79,7 @@ fun AlarmAddEditScreen(
             modifier = Modifier.weight(1f),
             contentAlignment = Alignment.Center,
         ) {
-            OrbitPicker(
-                selectedAmPm = state.currentAmPm,
-                selectedHour = state.currentHour,
-                selectedMinute = state.currentMinute,
-            ) { amPm, hour, minute ->
+            OrbitPicker { amPm, hour, minute ->
                 eventDispatcher(AlarmAddEditContract.Action.UpdateAlarmTime(amPm, hour, minute))
             }
         }

--- a/feature/onboarding/src/main/java/com/kms/onboarding/BirthdayScreen.kt
+++ b/feature/onboarding/src/main/java/com/kms/onboarding/BirthdayScreen.kt
@@ -1,5 +1,6 @@
 package com.kms.onboarding
 
+import android.util.Log
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -7,11 +8,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
@@ -29,11 +25,6 @@ fun BirthdayScreen(
     onNextClick: () -> Unit,
     onBackClick: () -> Unit,
 ) {
-    var selectedLunar by remember { mutableStateOf("음력") }
-    var selectedYear by remember { mutableIntStateOf(1900) }
-    var selectedMonth by remember { mutableIntStateOf(1) }
-    var selectedDay by remember { mutableIntStateOf(1) }
-
     OnboardingScreen(
         currentStep = currentStep,
         totalSteps = totalSteps,
@@ -52,15 +43,8 @@ fun BirthdayScreen(
             )
             OrbitYearMonthPicker(
                 modifier = Modifier.padding(top = 60.dp),
-                selectedLunar = selectedLunar,
-                selectedYear = selectedYear,
-                selectedMonth = selectedMonth,
-                selectedDay = selectedDay,
             ) { lunar, year, month, day ->
-                selectedLunar = lunar
-                selectedYear = year
-                selectedMonth = month
-                selectedDay = day
+                Log.d("BirthdayScreen", "lunar: $lunar, year: $year, month: $month, day: $day")
             }
         }
     }

--- a/feature/onboarding/src/main/java/com/kms/onboarding/BirthdayScreen.kt
+++ b/feature/onboarding/src/main/java/com/kms/onboarding/BirthdayScreen.kt
@@ -1,6 +1,5 @@
 package com.kms.onboarding
 
-import android.util.Log
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -8,6 +7,11 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
@@ -25,6 +29,11 @@ fun BirthdayScreen(
     onNextClick: () -> Unit,
     onBackClick: () -> Unit,
 ) {
+    var selectedLunar by remember { mutableStateOf("음력") }
+    var selectedYear by remember { mutableIntStateOf(1900) }
+    var selectedMonth by remember { mutableIntStateOf(1) }
+    var selectedDay by remember { mutableIntStateOf(1) }
+
     OnboardingScreen(
         currentStep = currentStep,
         totalSteps = totalSteps,
@@ -43,8 +52,15 @@ fun BirthdayScreen(
             )
             OrbitYearMonthPicker(
                 modifier = Modifier.padding(top = 60.dp),
+                selectedLunar = selectedLunar,
+                selectedYear = selectedYear,
+                selectedMonth = selectedMonth,
+                selectedDay = selectedDay,
             ) { lunar, year, month, day ->
-                Log.d("BirthdayScreen", "lunar: $lunar, year: $year, month: $month, day: $day")
+                selectedLunar = lunar
+                selectedYear = year
+                selectedMonth = month
+                selectedDay = day
             }
         }
     }

--- a/feature/onboarding/src/main/java/com/kms/onboarding/OnboardingAlarmTimeSelectionScreen.kt
+++ b/feature/onboarding/src/main/java/com/kms/onboarding/OnboardingAlarmTimeSelectionScreen.kt
@@ -29,6 +29,10 @@ fun OnboardingAlarmTimeSelectionScreen(
     onNextClick: () -> Unit,
     onBackClick: () -> Unit,
 ) {
+    var selectedAmPm by remember { mutableStateOf("오전") }
+    var selectedHour by remember { mutableIntStateOf(1) }
+    var selectedMinute by remember { mutableIntStateOf(0) }
+
     OnboardingScreen(
         currentStep = currentStep,
         totalSteps = totalSteps,

--- a/feature/onboarding/src/main/java/com/kms/onboarding/OnboardingAlarmTimeSelectionScreen.kt
+++ b/feature/onboarding/src/main/java/com/kms/onboarding/OnboardingAlarmTimeSelectionScreen.kt
@@ -65,9 +65,6 @@ fun OnboardingAlarmTimeSelectionScreen(
 
             OrbitPicker(
                 modifier = Modifier.padding(top = 90.dp),
-                selectedAmPm = selectedAmPm,
-                selectedHour = selectedHour,
-                selectedMinute = selectedMinute,
             ) { amPm, hour, minute ->
                 selectedAmPm = amPm
                 selectedHour = hour

--- a/feature/onboarding/src/main/java/com/kms/onboarding/OnboardingBirthdayScreen.kt
+++ b/feature/onboarding/src/main/java/com/kms/onboarding/OnboardingBirthdayScreen.kt
@@ -1,5 +1,6 @@
 package com.kms.onboarding
 
+import android.util.Log
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -7,11 +8,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
@@ -30,11 +26,6 @@ fun OnboardingBirthdayScreen(
     onNextClick: () -> Unit,
     onBackClick: () -> Unit,
 ) {
-    var selectedLunar by remember { mutableStateOf("음력") }
-    var selectedYear by remember { mutableIntStateOf(1900) }
-    var selectedMonth by remember { mutableIntStateOf(1) }
-    var selectedDay by remember { mutableIntStateOf(1) }
-
     OnboardingScreen(
         currentStep = currentStep,
         totalSteps = totalSteps,
@@ -59,15 +50,8 @@ fun OnboardingBirthdayScreen(
 
             OrbitYearMonthPicker(
                 modifier = Modifier.padding(top = 60.dp),
-                selectedLunar = selectedLunar,
-                selectedYear = selectedYear,
-                selectedMonth = selectedMonth,
-                selectedDay = selectedDay,
             ) { lunar, year, month, day ->
-                selectedLunar = lunar
-                selectedYear = year
-                selectedMonth = month
-                selectedDay = day
+                Log.d("BirthdayScreen", "lunar: $lunar, year: $year, month: $month, day: $day")
             }
         }
     }

--- a/feature/onboarding/src/main/java/com/kms/onboarding/OnboardingBirthdayScreen.kt
+++ b/feature/onboarding/src/main/java/com/kms/onboarding/OnboardingBirthdayScreen.kt
@@ -43,11 +43,6 @@ fun OnboardingBirthdayScreen(
                 textAlign = TextAlign.Center,
             )
 
-            var selectedLunar by remember { mutableStateOf("음력") }
-            var selectedYear by remember { mutableIntStateOf(1900) }
-            var selectedMonth by remember { mutableIntStateOf(1) }
-            var selectedDay by remember { mutableIntStateOf(1) }
-
             OrbitYearMonthPicker(
                 modifier = Modifier.padding(top = 60.dp),
             ) { lunar, year, month, day ->

--- a/feature/onboarding/src/main/java/com/kms/onboarding/OnboardingBirthdayScreen.kt
+++ b/feature/onboarding/src/main/java/com/kms/onboarding/OnboardingBirthdayScreen.kt
@@ -30,6 +30,11 @@ fun OnboardingBirthdayScreen(
     onNextClick: () -> Unit,
     onBackClick: () -> Unit,
 ) {
+    var selectedLunar by remember { mutableStateOf("음력") }
+    var selectedYear by remember { mutableIntStateOf(1900) }
+    var selectedMonth by remember { mutableIntStateOf(1) }
+    var selectedDay by remember { mutableIntStateOf(1) }
+
     OnboardingScreen(
         currentStep = currentStep,
         totalSteps = totalSteps,
@@ -54,6 +59,10 @@ fun OnboardingBirthdayScreen(
 
             OrbitYearMonthPicker(
                 modifier = Modifier.padding(top = 60.dp),
+                selectedLunar = selectedLunar,
+                selectedYear = selectedYear,
+                selectedMonth = selectedMonth,
+                selectedDay = selectedDay,
             ) { lunar, year, month, day ->
                 selectedLunar = lunar
                 selectedYear = year


### PR DESCRIPTION
## Related issue 🛠
[//]: # (해당하는 이슈 번호 달아주기)
closed #35 
closes #36 

어떤 변경사항이 있었나요?
- [x] 🐞 BugFix Something isn't working
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [] ✨ Feature Feature
- [ ] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (Junit, etc.)

## CheckPoint ✅
[//]: # (PR 요구사항 확인)
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 컨벤션에 맞게 작성했습니다. (필수)
- [x] merge할 브랜치의 위치를 확인해 주세요(main❌/develop⭕) (필수)
- [x] Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다. (필수)
- [x] BugFix의 경우, 버그의 원인을 파악하였습니다. (선택)

## Work Description ✏️
[//]: # (작업 내용 간단 소개)

https://github.com/user-attachments/assets/1c49bf1a-6103-4e27-918e-75c7abeca6d6

해당 2가지 문제가 있었습니다.

1. LazyListState의 초기화 로직이 재구성 시 여러 번 실행되며, 예상치 못한 스크롤 동작을 유발.
2. selectedItem 값이 재구성 이후에도 부모와 불일치하여 상태 꼬임 발생.

이를 해결하기 위해 다음 방안을 적용하였습니다.
 
1. PickerState를 통해 LazyListState, startIndex, selectedItem을 묶어서 관리
2. rememberPickerState를 활용하여 LazyListState와 startIndex의 초기화 로직이 Recomposition 시 여러 번 실행되지 않도록 제어

또한, onScrollCompleted()를 통해 PickerItem의 값들이 한바퀴 이상 순환할 경우 호출할 메소드를 넣을 수 있도록 하였습니다.

```kotlin
if ((previousAdjustedIndex == 0 && adjustedIndex == lastIndex) || 
    (previousAdjustedIndex == lastIndex && adjustedIndex == 0)) {
    onScrollCompleted()
}
```

해당 변경사항을 통해 hour이 한바퀴 이상 순환할 경우 AM/PM이 토글되도록 하였습니다.

## Uncompleted Tasks 😅
[//]: # (없다면 N/A)
N/A

## To Reviewers 📢
[//]: # (reviewer가 알면 좋은 내용들)
행복해요