### PR TITLE
[FEAT] 활성화된 알람이 없을 시 다이얼로그를 노출하고 화면 문구를 변경한다

### DIFF
--- a/feature/home/src/main/java/com/yapp/home/HomeContract.kt
+++ b/feature/home/src/main/java/com/yapp/home/HomeContract.kt
@@ -22,6 +22,8 @@ sealed class HomeContract {
     ) : UiState {
         val isAllSelected: Boolean
             get() = alarms.isNotEmpty() && selectedAlarmIds.size == alarms.size
+        val hasActivatedAlarm: Boolean
+            get() = alarms.any { it.isAlarmActive }
     }
 
     sealed class Action {

--- a/feature/home/src/main/java/com/yapp/home/HomeContract.kt
+++ b/feature/home/src/main/java/com/yapp/home/HomeContract.kt
@@ -16,6 +16,8 @@ sealed class HomeContract {
         val selectedAlarmIds: Set<Long> = emptySet(),
         val isSelectionMode: Boolean = false,
         val isDeleteDialogVisible: Boolean = false,
+        val isNoActivatedAlarmDialogVisible: Boolean = false,
+        val pendingAlarmToggle: Pair<Long, Boolean>? = null,
         val lastFortuneScore: Int = -1,
         val deliveryTime: String = "받을 수 있는 운세가 없어요",
         val name: String = "동현",
@@ -35,6 +37,9 @@ sealed class HomeContract {
         data object ToggleAllAlarmSelection : Action()
         data object ShowDeleteDialog : Action()
         data object HideDeleteDialog : Action()
+        data object ShowNoActivatedAlarmDialog : Action()
+        data object HideNoActivatedAlarmDialog : Action()
+        data object RollbackPendingAlarmToggle : Action()
         data object ConfirmDeletion : Action()
         data class DeleteSingleAlarm(val alarmId: Long) : Action()
         data object LoadMoreAlarms : Action()

--- a/feature/home/src/main/java/com/yapp/home/HomeScreen.kt
+++ b/feature/home/src/main/java/com/yapp/home/HomeScreen.kt
@@ -332,6 +332,21 @@ private fun HomeContent(
             },
         )
     }
+
+    if (state.isNoActivatedAlarmDialogVisible) {
+        OrbitDialog(
+            title = stringResource(id = R.string.no_active_alarm_dialog_title),
+            message = stringResource(id = R.string.no_active_alarm_dialog_message),
+            confirmText = stringResource(id = R.string.no_active_alarm_dialog_btn_confirm),
+            cancelText = stringResource(id = R.string.no_active_alarm_dialog_btn_cancel),
+            onConfirm = {
+                eventDispatcher(HomeContract.Action.HideNoActivatedAlarmDialog)
+            },
+            onCancel = {
+                eventDispatcher(HomeContract.Action.RollbackPendingAlarmToggle)
+            },
+        )
+    }
 }
 
 @Composable

--- a/feature/home/src/main/java/com/yapp/home/HomeScreen.kt
+++ b/feature/home/src/main/java/com/yapp/home/HomeScreen.kt
@@ -282,11 +282,13 @@ private fun HomeContent(
 
                     HomeCharacterAnimation(
                         fortuneScore = state.lastFortuneScore,
+                        hasActivatedAlarm = state.hasActivatedAlarm,
                         eventDispatcher = eventDispatcher,
                     )
                     Spacer(modifier = Modifier.height(8.dp))
                     HomeFortuneDescription(
                         fortuneScore = state.lastFortuneScore,
+                        hasActivatedAlarm = state.hasActivatedAlarm,
                         name = state.name,
                         deliveryTime = state.deliveryTime,
                     )
@@ -452,28 +454,31 @@ fun SkyImage() {
 private fun HomeCharacterAnimation(
     modifier: Modifier = Modifier,
     fortuneScore: Int,
+    hasActivatedAlarm: Boolean,
     eventDispatcher: (HomeContract.Action) -> Unit,
 ) {
-    val (bubbleRes, starRes) = when (fortuneScore) {
-        in 0..49 -> {
+    val (bubbleRes, starRes) = when {
+        !hasActivatedAlarm -> {
+            Pair(null, core.designsystem.R.raw.fortune_preload)
+        }
+        fortuneScore in 0..49 -> {
             Pair(
                 core.designsystem.R.drawable.ic_fortune_0_to_49_speech_bubble,
                 core.designsystem.R.raw.fortune_0_to_49,
             )
         }
-        in 50..79 -> {
+        fortuneScore in 50..79 -> {
             Pair(
                 core.designsystem.R.drawable.ic_fortune_50_to_79_speech_bubble,
                 core.designsystem.R.raw.fortune_50_to_79,
             )
         }
-        in 80..100 -> {
+        fortuneScore in 80..100 -> {
             Pair(
                 core.designsystem.R.drawable.ic_fortune_80_to_100_speech_bubble,
                 core.designsystem.R.raw.fortune_80_to_100,
             )
         }
-
         else -> {
             Pair(
                 core.designsystem.R.drawable.ic_fortune_preload_speech_bubble,
@@ -486,16 +491,19 @@ private fun HomeCharacterAnimation(
         modifier = modifier,
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
-        Image(
-            painter = painterResource(id = bubbleRes),
-            contentDescription = "IMG_MAIN_SPEECH_BUBBLE",
-        )
-        Spacer(modifier = Modifier.height(16.dp))
+        bubbleRes?.let {
+            Image(
+                modifier = Modifier.height(46.dp),
+                painter = painterResource(id = it),
+                contentDescription = "IMG_MAIN_SPEECH_BUBBLE",
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+        } ?: Spacer(modifier = Modifier.height(62.dp))
         LottieAnimation(
             modifier = Modifier
                 .size(110.dp)
                 .clickable {
-                    eventDispatcher(HomeContract.Action.FakeAction) // ✅ 클릭 시 이동
+                    eventDispatcher(HomeContract.Action.FakeAction)
                 },
             resId = starRes,
         )
@@ -506,13 +514,15 @@ private fun HomeCharacterAnimation(
 private fun HomeFortuneDescription(
     modifier: Modifier = Modifier,
     fortuneScore: Int,
+    hasActivatedAlarm: Boolean,
     name: String,
     deliveryTime: String,
 ) {
-    val descriptionRes = when (fortuneScore) {
-        in 0..49 -> R.string.home_fortune_0_to_49_description
-        in 50..79 -> R.string.home_fortune_50_to_79_description
-        in 80..100 -> R.string.home_fortune_80_to_100_description
+    val descriptionRes = when {
+        !hasActivatedAlarm -> R.string.home_fortune_no_alarm_description
+        fortuneScore in 0..49 -> R.string.home_fortune_0_to_49_description
+        fortuneScore in 50..79 -> R.string.home_fortune_50_to_79_description
+        fortuneScore in 80..100 -> R.string.home_fortune_80_to_100_description
         else -> R.string.home_fortune_preload_description
     }
 

--- a/feature/home/src/main/res/values/strings.xml
+++ b/feature/home/src/main/res/values/strings.xml
@@ -67,6 +67,11 @@
     <string name="alarm_unsaved_changes_dialog_btn_cancel">취소</string>
     <string name="alarm_unsaved_changes_dialog_btn_discard">나가기</string>
 
+    <string name="no_active_alarm_dialog_title">모든 알람 해제</string>
+    <string name="no_active_alarm_dialog_message">알람을 설정하지 않으면\n운세 편지를 받을 수 없어요.</string>
+    <string name="no_active_alarm_dialog_btn_cancel">취소</string>
+    <string name="no_active_alarm_dialog_btn_confirm">확인</string>
+
     <string name="alarm_disabled_warning">알람을 끄면 운세가 도착하지 않아요.</string>
     <string name="alarm_already_set">선택한 시간에 이미 설정된 알람이 있어요.</string>
     <string name="alarm_deleted">삭제되었어요.</string>

--- a/feature/home/src/main/res/values/strings.xml
+++ b/feature/home/src/main/res/values/strings.xml
@@ -4,6 +4,7 @@
     <string name="home_empty_title">기상 알림이 없어요</string>
     <string name="home_empty_description">알림을 추가하고\n운세 편지를 받아보세요</string>
 
+    <string name="home_fortune_no_alarm_description">운세 편지를 받고 싶다면\n기상 알람을 켜줘</string>
     <string name="home_fortune_preload_description">미래에서 운세 편지를\n작성 중이야!</string>
     <string name="home_fortune_0_to_49_description">오늘 %s의 하루는\n주의가 필요해</string>
     <string name="home_fortune_50_to_79_description">오늘 %s의 하루는\n최고야!</string>


### PR DESCRIPTION
## Related issue 🛠
[//]: # (해당하는 이슈 번호 달아주기)
closed #95 

어떤 변경사항이 있었나요?
- [ ] 🐞 BugFix Something isn't working
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [x] ✨ Feature Feature
- [ ] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (Junit, etc.)

## CheckPoint ✅
[//]: # (PR 요구사항 확인)
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 컨벤션에 맞게 작성했습니다. (필수)
- [x] merge할 브랜치의 위치를 확인해 주세요(main❌/develop⭕) (필수)
- [x] Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다. (필수)
- [ ] BugFix의 경우, 버그의 원인을 파악하였습니다. (선택)

## Work Description ✏️
[//]: # (작업 내용 간단 소개)

https://github.com/user-attachments/assets/04885121-99cb-4c6d-b413-68af06649e15

- 홈 화면 활성화된 알람이 없을 시 문구 변경
- 홈 화면 활성화된 알람이 없을 시 다이얼로그 노출

## Uncompleted Tasks 😅
[//]: # (없다면 N/A)
N/A

## To Reviewers 📢
[//]: # (reviewer가 알면 좋은 내용들)
