### PR TITLE
[REFACTOR/YAF-000] Click Ripple Effect를 수정하고 프로필 수정 버튼 Enable 속성을 부여합니다.

### DIFF
--- a/build-logic/src/main/java/com/yapp/convention/Extension.kt
+++ b/build-logic/src/main/java/com/yapp/convention/Extension.kt
@@ -27,12 +27,11 @@ internal val ExtensionContainer.libs: VersionCatalog
 
 internal fun CommonExtension<*, *, *, *, *, *>.addBuildConfigFields(project: Project) {
     val baseUrl = project.getLocalProperty("baseUrl", "https://default.example.com")
-    val isDebug = project.providers.gradleProperty("isDebug").orNull?.toBoolean() ?: false
 
     buildTypes {
         getByName("debug") {
             buildConfigField("String", "BASE_URL", "\"$baseUrl\"")
-            buildConfigField("boolean", "DEBUG", isDebug.toString())
+            buildConfigField("boolean", "DEBUG", "true")
         }
         getByName("release") {
             buildConfigField("String", "BASE_URL", "\"$baseUrl\"")

--- a/core/ui/src/main/java/com/yapp/ui/component/textfield/OrbitTextField.kt
+++ b/core/ui/src/main/java/com/yapp/ui/component/textfield/OrbitTextField.kt
@@ -48,7 +48,7 @@ fun OrbitTextField(
     modifier: Modifier = Modifier,
     showWarning: Boolean = false,
     isValid: Boolean = false,
-    warningMessage: String,
+    warningMessage: String? = null,
     focusRequester: FocusRequester? = null,
     keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
     keyboardActions: KeyboardActions = KeyboardActions.Default,
@@ -96,9 +96,11 @@ fun OrbitTextField(
                     enabled = enabled,
                 )
 
-                Box {
-                    if (showWarning) {
-                        WarningMessage(warningMessage, textAlign)
+                when (showWarning) {
+                    true -> warningMessage?.let {
+                        WarningMessage(it, textAlign)
+                    }
+                    false -> {
                     }
                 }
             }

--- a/core/ui/src/main/java/com/yapp/ui/component/textfield/OrbitTextField.kt
+++ b/core/ui/src/main/java/com/yapp/ui/component/textfield/OrbitTextField.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.text.selection.LocalTextSelectionColors
 import androidx.compose.foundation.text.selection.TextSelectionColors
@@ -50,6 +51,7 @@ fun OrbitTextField(
     warningMessage: String,
     focusRequester: FocusRequester? = null,
     keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
+    keyboardActions: KeyboardActions = KeyboardActions.Default,
     textAlign: TextAlign = TextAlign.Center,
     enabled: Boolean = true,
 ) {
@@ -87,6 +89,7 @@ fun OrbitTextField(
                     onFocusChanged = { isFocused = it },
                     focusRequester = actualFocusRequester,
                     keyboardOptions = keyboardOptions,
+                    keyboardActions = keyboardActions,
                     isValid = isValid,
                     isFocused = isFocused,
                     textAlign = textAlign,
@@ -134,6 +137,7 @@ private fun TextFieldContainer(
     focusRequester: FocusRequester,
     onFocusChanged: (Boolean) -> Unit,
     keyboardOptions: KeyboardOptions,
+    keyboardActions: KeyboardActions,
     textAlign: TextAlign,
     enabled: Boolean,
 ) {
@@ -185,7 +189,9 @@ private fun TextFieldContainer(
                 },
                 textAlign = textAlign,
             ),
+            singleLine = true,
             keyboardOptions = keyboardOptions,
+            keyboardActions = keyboardActions,
             cursorBrush = SolidColor(OrbitTheme.colors.white),
             enabled = enabled,
             decorationBox = { innerTextField ->

--- a/core/ui/src/main/java/com/yapp/ui/extensions/CustomClickable.kt
+++ b/core/ui/src/main/java/com/yapp/ui/extensions/CustomClickable.kt
@@ -6,10 +6,14 @@ import androidx.compose.foundation.indication
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.material3.ripple
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
 
 @Composable
@@ -17,6 +21,8 @@ fun Modifier.customClickable(
     rippleEnabled: Boolean = true,
     rippleColor: Color? = null,
     enabled: Boolean = true,
+    fadeOnPress: Boolean = false,
+    pressedAlpha: Float = 0.5f,
     onClick: (() -> Unit)?,
     onLongClick: (() -> Unit)? = null,
     onPress: (() -> Unit)? = null,
@@ -30,18 +36,27 @@ fun Modifier.customClickable(
             null
         }
 
+        var isPressed by remember { mutableStateOf(false) }
+
         this.then(
             Modifier
                 .pointerInput(Unit) {
                     detectTapGestures(
                         onPress = {
+                            isPressed = true
                             onPress?.invoke()
                             tryAwaitRelease()
+                            isPressed = false
                             onRelease?.invoke()
                         },
                         onTap = { onClick?.invoke() },
                         onLongPress = { onLongClick?.invoke() },
                     )
+                }
+                .graphicsLayer {
+                    if (fadeOnPress) {
+                        alpha = if (isPressed) pressedAlpha else 1f
+                    }
                 }
                 .indication(interactionSource, rippleIndication),
         )

--- a/feature/fortune/src/main/java/com/yapp/fortune/component/FortuneTopAppBar.kt
+++ b/feature/fortune/src/main/java/com/yapp/fortune/component/FortuneTopAppBar.kt
@@ -35,7 +35,12 @@ fun FortuneTopAppBar(
                 painter = painterResource(id = core.designsystem.R.drawable.ic_close),
                 contentDescription = "Close",
                 modifier = Modifier
-                    .customClickable(onClick = onCloseClick),
+                    .customClickable(
+                        rippleEnabled = false,
+                        fadeOnPress = true,
+                        pressedAlpha = 0.5f,
+                        onClick = onCloseClick,
+                    ),
                 tint = OrbitTheme.colors.white,
             )
             Spacer(modifier = Modifier.padding(end = 12.dp))

--- a/feature/mission/src/main/java/com/yapp/mission/MissionProgressScreen.kt
+++ b/feature/mission/src/main/java/com/yapp/mission/MissionProgressScreen.kt
@@ -8,7 +8,6 @@ import androidx.compose.animation.fadeIn
 import androidx.compose.animation.scaleIn
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -41,6 +40,7 @@ import com.yapp.mission.component.FlipCard
 import com.yapp.mission.component.MissionProgressBar
 import com.yapp.ui.component.dialog.OrbitDialog
 import com.yapp.ui.component.lottie.LottieAnimation
+import com.yapp.ui.extensions.customClickable
 import com.yapp.ui.utils.heightForScreenPercentage
 import com.yapp.ui.utils.paddingForScreenPercentage
 
@@ -107,9 +107,12 @@ fun MissionProgressScreen(
                 ) {
                     Row(
                         modifier = Modifier
-                            .clickable {
-                                eventDispatcher(MissionContract.Action.ShowExitDialog)
-                            },
+                            .customClickable(
+                                rippleEnabled = false,
+                                fadeOnPress = true,
+                                pressedAlpha = 0.5f,
+                                onClick = { eventDispatcher(MissionContract.Action.ShowExitDialog) },
+                            ),
                     ) {
                         Icon(
                             painter = painterResource(id = core.designsystem.R.drawable.ic_cancel),

--- a/feature/onboarding/src/main/java/com/yapp/onboarding/OnboardingGenderScreen.kt
+++ b/feature/onboarding/src/main/java/com/yapp/onboarding/OnboardingGenderScreen.kt
@@ -46,7 +46,6 @@ fun OnboardingGenderRoute(
         },
         onDismissRequest = {
             viewModel.processAction(OnboardingContract.Action.ToggleBottomSheet)
-            viewModel.processAction(OnboardingContract.Action.PreviousStep)
         },
         onConfirmRequest = {
             viewModel.processAction(OnboardingContract.Action.ToggleBottomSheet)

--- a/feature/onboarding/src/main/java/com/yapp/onboarding/OnboardingNameScreen.kt
+++ b/feature/onboarding/src/main/java/com/yapp/onboarding/OnboardingNameScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -118,6 +119,11 @@ fun OnboardingNameScreen(
                 modifier = Modifier
                     .fillMaxWidth()
                     .paddingForScreenPercentage(horizontalPercentage = 0.192f, topPercentage = 0.086f),
+                keyboardActions = KeyboardActions(
+                    onDone = {
+                        focusManager.clearFocus()
+                    },
+                ),
             )
         }
     }

--- a/feature/onboarding/src/main/java/com/yapp/onboarding/component/OnbardingTopAppBar.kt
+++ b/feature/onboarding/src/main/java/com/yapp/onboarding/component/OnbardingTopAppBar.kt
@@ -1,7 +1,6 @@
 package com.yapp.onboarding.component
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -19,6 +18,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.yapp.designsystem.theme.OrbitTheme
+import com.yapp.ui.extensions.customClickable
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -37,7 +37,12 @@ fun OnBoardingTopAppBar(
                     contentDescription = "Back",
                     tint = OrbitTheme.colors.white,
                     modifier = Modifier
-                        .clickable(onClick = onBackClick)
+                        .customClickable(
+                            rippleEnabled = false,
+                            fadeOnPress = true,
+                            pressedAlpha = 0.5f,
+                            onClick = onBackClick,
+                        )
                         .padding(start = 20.dp),
                 )
             }
@@ -67,5 +72,10 @@ fun OnBoardingTopAppBar(
 @Composable
 @Preview
 fun OnBoardingTopAppBarPreview() {
-    OnBoardingTopAppBar(currentStep = 1, totalSteps = 3)
+    OnBoardingTopAppBar(
+        currentStep = 1,
+        totalSteps = 3,
+        onBackClick = {},
+        showTopAppBarActions = true,
+    )
 }

--- a/feature/setting/src/main/java/com/yapp/setting/EditBirthdayScreen.kt
+++ b/feature/setting/src/main/java/com/yapp/setting/EditBirthdayScreen.kt
@@ -72,6 +72,7 @@ fun EditBirthdayScreen(
             showTopAppBarActions = true,
             title = "생년월일 수정",
             actionTitle = "확인",
+            isActionEnabled = true,
             onActionClick = {
                 onConfirm()
             },

--- a/feature/setting/src/main/java/com/yapp/setting/EditProfileScreen.kt
+++ b/feature/setting/src/main/java/com/yapp/setting/EditProfileScreen.kt
@@ -20,10 +20,13 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -95,17 +98,19 @@ fun EditProfileScreen(
 ) {
     val focusManager = LocalFocusManager.current
 
-    val nameTextFieldValue = remember(state.name) {
-        TextFieldValue(
-            text = state.name,
-            selection = TextRange(state.name.length),
-        )
+    val nameTextFieldValue = remember { mutableStateOf(TextFieldValue(state.name)) }
+    val birthTimeTextFieldValue = remember { mutableStateOf(TextFieldValue(state.timeOfBirth)) }
+
+    LaunchedEffect(state.name) {
+        if (state.name != nameTextFieldValue.value.text) {
+            nameTextFieldValue.value = TextFieldValue(state.name)
+        }
     }
-    val birthTimeTextFieldValue = remember(state.timeOfBirth) {
-        TextFieldValue(
-            text = state.timeOfBirth,
-            selection = TextRange(state.timeOfBirth.length),
-        )
+
+    LaunchedEffect(state.timeOfBirth) {
+        if (state.timeOfBirth != birthTimeTextFieldValue.value.text) {
+            birthTimeTextFieldValue.value = TextFieldValue(state.timeOfBirth)
+        }
     }
 
     Column(
@@ -124,6 +129,7 @@ fun EditProfileScreen(
             title = "프로필 수정",
             actionTitle = "저장",
             onActionClick = onSaveUserInfo,
+            isActionEnabled = state.isActionEnabled,
         )
 
         Column(
@@ -138,8 +144,9 @@ fun EditProfileScreen(
             )
             Spacer(modifier = Modifier.height(8.dp))
             OrbitTextField(
-                text = nameTextFieldValue,
+                text = nameTextFieldValue.value,
                 onTextChange = { newValue ->
+                    nameTextFieldValue.value = newValue
                     onUpdateName(newValue.text)
                 },
                 hint = "이름 입력",
@@ -150,6 +157,9 @@ fun EditProfileScreen(
                     .fillMaxWidth()
                     .padding(horizontal = 18.dp),
                 textAlign = TextAlign.Start,
+                keyboardActions = KeyboardActions(
+                    onDone = { focusManager.clearFocus() },
+                ),
             )
             Spacer(modifier = Modifier.height(18.dp))
             ContentsTitle(
@@ -210,19 +220,24 @@ fun EditProfileScreen(
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
                     OrbitTextField(
-                        text = birthTimeTextFieldValue,
+                        text = birthTimeTextFieldValue.value,
                         onTextChange = { newValue ->
-                            val formattedTime = formatTimeInput(newValue.text, state.timeOfBirth)
-                            onUpdateTimeOfBirth(formattedTime)
+                            val formattedValue = formatTimeInput(newValue.text, state.timeOfBirth)
+                            birthTimeTextFieldValue.value = formattedValue
+                            onUpdateTimeOfBirth(formattedValue.text)
                         },
                         hint = "시간모름",
                         isValid = state.isTimeValid,
                         showWarning = !state.isTimeValid,
-                        warningMessage = "올바른 시간을 입력해주세요.",
                         enabled = !state.isTimeUnknown,
                         modifier = Modifier
                             .weight(1f),
                         textAlign = TextAlign.Start,
+                        keyboardActions = KeyboardActions(
+                            onDone = {
+                                focusManager.clearFocus()
+                            },
+                        ),
                     )
                     Spacer(modifier = Modifier.width(12.dp))
 
@@ -239,7 +254,7 @@ fun EditProfileScreen(
                         color = if (state.isTimeUnknown) OrbitTheme.colors.main else OrbitTheme.colors.white,
                     )
                 }
-                if (!state.isTimeValid) {
+                if (!state.isTimeUnknown && !state.isTimeValid) {
                     WarningMessage(
                         message = "올바른 시간을 입력해주세요.",
                         textAlign = TextAlign.Start,
@@ -261,11 +276,11 @@ fun EditProfileScreen(
     }
 }
 
-fun formatTimeInput(input: String, previousText: String): String {
+fun formatTimeInput(input: String, previousText: String): TextFieldValue {
     val sanitizedValue = input.filter { it.isDigit() }
     val isDeleting = sanitizedValue.length < previousText.filter { it.isDigit() }.length
 
-    return when {
+    val newText = when {
         isDeleting && previousText.endsWith(":") -> sanitizedValue
         sanitizedValue.length > 2 -> {
             val hours = sanitizedValue.take(2)
@@ -283,6 +298,13 @@ fun formatTimeInput(input: String, previousText: String): String {
 
         else -> sanitizedValue
     }
+    val cursorPosition = if (newText.length == 3 && newText.endsWith(":")) {
+        3
+    } else {
+        newText.length
+    }
+
+    return TextFieldValue(newText, TextRange(cursorPosition))
 }
 
 @Composable

--- a/feature/setting/src/main/java/com/yapp/setting/EditProfileViewModel.kt
+++ b/feature/setting/src/main/java/com/yapp/setting/EditProfileViewModel.kt
@@ -53,6 +53,7 @@ class EditProfileViewModel @Inject constructor(
                 copy(
                     isMaleSelected = action.isMale,
                     isFemaleSelected = !action.isMale,
+                    selectedGender = if (action.isMale) "남성" else "여성",
                 )
             }
 
@@ -135,7 +136,16 @@ class EditProfileViewModel @Inject constructor(
 
         if (result.isSuccess) {
             Log.d("EditProfileViewModel", "사용자 정보 수정 성공")
-            emitSideEffect(SettingContract.SideEffect.NavigateBack)
+
+            emitSideEffect(SettingContract.SideEffect.UserInfoUpdated)
+
+            emitSideEffect(
+                SettingContract.SideEffect.Navigate(
+                    route = SettingDestination.Setting.route,
+                    popUpTo = SettingDestination.Setting.route,
+                    inclusive = true,
+                ),
+            )
         } else {
             Log.e("EditProfileViewModel", "사용자 정보 수정 실패")
         }

--- a/feature/setting/src/main/java/com/yapp/setting/EditProfileViewModel.kt
+++ b/feature/setting/src/main/java/com/yapp/setting/EditProfileViewModel.kt
@@ -146,7 +146,6 @@ class EditProfileViewModel @Inject constructor(
                     inclusive = true,
                 ),
             )
-
         } else {
             Log.e("EditProfileViewModel", "사용자 정보 수정 실패")
         }

--- a/feature/setting/src/main/java/com/yapp/setting/SettingContract.kt
+++ b/feature/setting/src/main/java/com/yapp/setting/SettingContract.kt
@@ -28,6 +28,8 @@ sealed class SettingContract {
 
                 return "$birthType $year $month $day"
             }
+        val isActionEnabled: Boolean
+            get() = isNameValid && isTimeValid && selectedGender != null
     }
 
     sealed class Action {
@@ -47,6 +49,7 @@ sealed class SettingContract {
         data object HideDialog : Action()
         data object SubmitUserInfo : Action()
         data class OpenWebView(val url: String) : Action()
+        data object RefreshUserInfo : Action()
     }
 
     enum class FieldType(val validationRegex: Regex) {
@@ -63,5 +66,6 @@ sealed class SettingContract {
 
         data object NavigateBack : SideEffect()
         data class OpenWebView(val url: String) : SideEffect()
+        data object UserInfoUpdated : SideEffect()
     }
 }

--- a/feature/setting/src/main/java/com/yapp/setting/SettingNavGraph.kt
+++ b/feature/setting/src/main/java/com/yapp/setting/SettingNavGraph.kt
@@ -130,5 +130,6 @@ private fun handleSettingSideEffect(
         is SettingContract.SideEffect.OpenWebView -> {
             navigator.navigateTo("${WebViewDestination.WebView.route}/${Uri.encode(sideEffect.url)}")
         }
+        else -> {}
     }
 }

--- a/feature/setting/src/main/java/com/yapp/setting/SettingScreen.kt
+++ b/feature/setting/src/main/java/com/yapp/setting/SettingScreen.kt
@@ -1,7 +1,6 @@
 package com.yapp.setting
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -24,6 +23,7 @@ import com.yapp.setting.component.SettingTopAppBar
 import com.yapp.setting.component.TableOfContentsText
 import com.yapp.setting.component.UserInfoCard
 import com.yapp.setting.component.VersionCodeText
+import com.yapp.ui.extensions.customClickable
 
 @Composable
 fun SettingRoute(
@@ -85,7 +85,12 @@ fun SettingScreen(
             birth = state.birthDate,
             modifier = Modifier
                 .padding(horizontal = 24.dp)
-                .clickable { onNavigateToEditProfile() },
+                .customClickable(
+                    rippleEnabled = true,
+                    fadeOnPress = true,
+                    pressedAlpha = 0.5f,
+                    onClick = { onNavigateToEditProfile() },
+                ),
         )
         Spacer(modifier = Modifier.height(24.dp))
         InquiryCard(
@@ -107,18 +112,24 @@ fun SettingScreen(
         SettingItem(
             itemTitle = "이용약관",
             modifier = Modifier
-                .clickable {
-                    onTermsClick()
-                }
+                .customClickable(
+                    rippleEnabled = true,
+                    fadeOnPress = true,
+                    pressedAlpha = 0.5f,
+                    onClick = onTermsClick,
+                )
                 .padding(horizontal = 24.dp),
         )
         Spacer(modifier = Modifier.height(24.dp))
         SettingItem(
             itemTitle = "개인정보 처리방침",
             modifier = Modifier
-                .clickable {
-                    onPrivacyPolicyClick()
-                }
+                .customClickable(
+                    rippleEnabled = true,
+                    fadeOnPress = true,
+                    pressedAlpha = 0.5f,
+                    onClick = onPrivacyPolicyClick,
+                )
                 .padding(horizontal = 24.dp),
         )
         Spacer(modifier = Modifier.weight(1f))

--- a/feature/setting/src/main/java/com/yapp/setting/SettingScreen.kt
+++ b/feature/setting/src/main/java/com/yapp/setting/SettingScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
@@ -31,6 +32,10 @@ fun SettingRoute(
 ) {
     val state by viewModel.container.stateFlow.collectAsStateWithLifecycle()
 
+    LaunchedEffect(Unit) {
+        viewModel.refreshUserInfo() // 이걸 어찌 할까요
+    }
+
     SettingScreen(
         state = state,
         onNavigateToEditProfile = {
@@ -41,7 +46,7 @@ fun SettingRoute(
         onBackClick = { viewModel.onAction(SettingContract.Action.PreviousStep) },
         onInquiryClick = {
             viewModel.onAction(
-                SettingContract.Action.OpenWebView("http://pf.kakao.com/_YxiPsn/chat"),
+                SettingContract.Action.OpenWebView("https://forms.gle/Q6wpKj3YAyS2jxq57"),
             )
         },
         onTermsClick = {

--- a/feature/setting/src/main/java/com/yapp/setting/SettingViewModel.kt
+++ b/feature/setting/src/main/java/com/yapp/setting/SettingViewModel.kt
@@ -7,6 +7,7 @@ import com.yapp.datastore.UserPreferences
 import com.yapp.domain.repository.UserInfoRepository
 import com.yapp.ui.base.BaseViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
 import org.orbitmvi.orbit.syntax.simple.intent
 import javax.inject.Inject
@@ -15,20 +16,28 @@ import javax.inject.Inject
 class SettingViewModel @Inject constructor(
     private val userInfoRepository: UserInfoRepository,
     private val userPreferences: UserPreferences,
-) :
-    BaseViewModel<SettingContract.State, SettingContract.SideEffect>(
-        SettingContract.State(),
-    ) {
-
-    init {
+) : BaseViewModel<SettingContract.State, SettingContract.SideEffect>(
+    SettingContract.State(),
+) {
+    fun refreshUserInfo() {
         viewModelScope.launch {
-            userPreferences.userIdFlow.collect { userId ->
-                if (userId != null) {
-                    fetchUserInfo(userId)
-                }
+            val userId = userPreferences.userIdFlow.firstOrNull()
+            if (userId != null) {
+                fetchUserInfo(userId)
             }
         }
     }
+
+//    init {
+//        viewModelScope.launch {
+//            container.sideEffectFlow.collect { sideEffect ->
+//                when (sideEffect) {
+//                    is SettingContract.SideEffect.UserInfoUpdated -> refreshUserInfo()
+//                    else -> {}
+//                }
+//            }
+//        }
+//    }
 
     fun onAction(action: SettingContract.Action) = intent {
         when (action) {

--- a/feature/setting/src/main/java/com/yapp/setting/component/InquiryCard.kt
+++ b/feature/setting/src/main/java/com/yapp/setting/component/InquiryCard.kt
@@ -2,7 +2,6 @@ package com.yapp.setting.component
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -21,6 +20,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.yapp.designsystem.theme.OrbitTheme
+import com.yapp.ui.extensions.customClickable
 
 @Composable
 fun InquiryCard(
@@ -76,7 +76,12 @@ fun InquirySendRow(
     Row(
         modifier = Modifier
             .wrapContentWidth()
-            .clickable(onClick = onInquiryClick)
+            .customClickable(
+                rippleEnabled = true,
+                fadeOnPress = true,
+                pressedAlpha = 0.5f,
+                onClick = onInquiryClick,
+            )
             .padding(horizontal = 4.dp, vertical = 6.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {

--- a/feature/setting/src/main/java/com/yapp/setting/component/SettingTopAppBar.kt
+++ b/feature/setting/src/main/java/com/yapp/setting/component/SettingTopAppBar.kt
@@ -65,7 +65,7 @@ fun SettingTopAppBar(
                     Text(
                         text = actionTitle ?: "",
                         style = OrbitTheme.typography.body1Medium,
-                        color = if (isActionEnabled) OrbitTheme.colors.white else OrbitTheme.colors.gray_300,
+                        color = if (isActionEnabled) OrbitTheme.colors.main else OrbitTheme.colors.gray_300,
                         modifier = Modifier
                             .padding(horizontal = 8.dp, vertical = 4.dp)
                             .clickable(

--- a/feature/setting/src/main/java/com/yapp/setting/component/SettingTopAppBar.kt
+++ b/feature/setting/src/main/java/com/yapp/setting/component/SettingTopAppBar.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.yapp.designsystem.theme.OrbitTheme
+import com.yapp.ui.extensions.customClickable
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -51,7 +52,12 @@ fun SettingTopAppBar(
                     contentDescription = "Back",
                     tint = OrbitTheme.colors.white,
                     modifier = Modifier
-                        .clickable(onClick = onBackClick)
+                        .customClickable(
+                            rippleEnabled = false,
+                            fadeOnPress = true,
+                            pressedAlpha = 0.5f,
+                            onClick = onBackClick,
+                        )
                         .padding(start = 20.dp),
                 )
             }

--- a/feature/setting/src/main/java/com/yapp/setting/component/SettingTopAppBar.kt
+++ b/feature/setting/src/main/java/com/yapp/setting/component/SettingTopAppBar.kt
@@ -1,8 +1,6 @@
 package com.yapp.setting.component
 
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -12,8 +10,6 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
@@ -31,10 +27,8 @@ fun SettingTopAppBar(
     showTopAppBarActions: Boolean = true,
     title: String,
     actionTitle: String? = null,
+    isActionEnabled: Boolean = false,
 ) {
-    val interactionSource = remember { MutableInteractionSource() }
-    val isPressed by interactionSource.collectIsPressedAsState()
-
     TopAppBar(
         title = {
             Text(
@@ -71,12 +65,11 @@ fun SettingTopAppBar(
                     Text(
                         text = actionTitle ?: "",
                         style = OrbitTheme.typography.body1Medium,
-                        color = if (isPressed) OrbitTheme.colors.main else OrbitTheme.colors.gray_500,
+                        color = if (isActionEnabled) OrbitTheme.colors.white else OrbitTheme.colors.gray_300,
                         modifier = Modifier
                             .padding(horizontal = 8.dp, vertical = 4.dp)
                             .clickable(
-                                interactionSource = interactionSource,
-                                indication = null,
+                                enabled = isActionEnabled,
                                 onClick = onActionClick,
                             ),
                     )


### PR DESCRIPTION
## Related issue 🛠
[//]: # (해당하는 이슈 번호 달아주기)
closed #147

어떤 변경사항이 있었나요?
- [ ] 🐞 BugFix Something isn't working
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [ ] ✨ Feature Feature
- [x] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (Junit, etc.)

## CheckPoint ✅
[//]: # (PR 요구사항 확인)
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] PR 컨벤션에 맞게 작성했습니다. (필수)
- [x] merge할 브랜치의 위치를 확인해 주세요(main❌/develop⭕) (필수)
- [x] Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다. (필수)
- [ ] BugFix의 경우, 버그의 원인을 파악하였습니다. (선택)

## Work Description ✏️
[//]: # (작업 내용 간단 소개)
- CustomClick을 각 컴포넌트 및 아이콘에 적용함(클릭 시 해당 아이템의 Alpha를 0.5로 설정)
- TextField에 SingleLine추가 및 KeyBoardAction을 통해 엔터 클릭 시 포커스 해제

## Uncompleted Tasks 😅
[//]: # (없다면 N/A)
- [ ] 

## To Reviewers 📢
[//]: # (reviewer가 알면 좋은 내용들)
CusomClickable이 문제가 있는 줄 알았는데 그게 아니라 SettingViewModel단에서 init으로 fetchUserInfo를 하면 두 번째 클릭부터 이벤트를 발행한다는 것을 알게되었습니다... 지금 현재 Route단에서 LaunchedEffect viewmodel.refreshUserInfo로 하면 되긴 하는데 이러면 비즈니스 로직 분리가 안되서 생각좀 해보고 다시 올리겠습니다