### PR TITLE
[FEAT] 홈 화면에서 확인하지 않은 운세가 있을 시 툴팁 띄우기

### DIFF
--- a/core/datastore/src/main/java/com/yapp/datastore/UserPreferences.kt
+++ b/core/datastore/src/main/java/com/yapp/datastore/UserPreferences.kt
@@ -29,6 +29,7 @@ class UserPreferences @Inject constructor(
         val FORTUNE_DATE = stringPreferencesKey("fortune_date")
         val FORTUNE_IMAGE_ID = intPreferencesKey("fortune_image_id")
         val FORTUNE_SCORE = intPreferencesKey("fortune_score")
+        val FORTUNE_CHECKED = booleanPreferencesKey("fortune_checked")
     }
 
     val userIdFlow: Flow<Long?> = dataStore.data
@@ -66,6 +67,16 @@ class UserPreferences @Inject constructor(
         .map { it[Keys.FORTUNE_SCORE] }
         .distinctUntilChanged()
 
+    val hasNewFortuneFlow: Flow<Boolean> = dataStore.data
+        .catch { emit(emptyPreferences()) }
+        .map { preferences ->
+            val savedDate = preferences[Keys.FORTUNE_DATE]
+            val isChecked = preferences[Keys.FORTUNE_CHECKED] ?: true
+            val todayDate = LocalDate.now().format(DateTimeFormatter.ISO_DATE)
+            savedDate == todayDate && !isChecked
+        }
+        .distinctUntilChanged()
+
     suspend fun saveUserId(userId: Long) {
         dataStore.edit { preferences ->
             preferences[Keys.USER_ID] = userId
@@ -83,6 +94,13 @@ class UserPreferences @Inject constructor(
         dataStore.edit { preferences ->
             preferences[Keys.FORTUNE_ID] = fortuneId
             preferences[Keys.FORTUNE_DATE] = currentDate
+            preferences[Keys.FORTUNE_CHECKED] = false
+        }
+    }
+
+    suspend fun markFortuneAsChecked() {
+        dataStore.edit { preferences ->
+            preferences[Keys.FORTUNE_CHECKED] = true
         }
     }
 
@@ -116,6 +134,7 @@ class UserPreferences @Inject constructor(
             preferences.remove(Keys.FORTUNE_DATE)
             preferences.remove(Keys.FORTUNE_IMAGE_ID)
             preferences.remove(Keys.FORTUNE_SCORE)
+            preferences.remove(Keys.FORTUNE_CHECKED)
         }
     }
 }

--- a/core/ui/src/main/java/com/yapp/ui/component/tooltip/OrbitToolTip.kt
+++ b/core/ui/src/main/java/com/yapp/ui/component/tooltip/OrbitToolTip.kt
@@ -1,0 +1,166 @@
+package com.yapp.ui.component.tooltip
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Outline
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Popup
+import com.yapp.designsystem.theme.OrbitTheme
+import com.yapp.ui.utils.toPx
+import com.yapp.ui.utils.toRoundPx
+
+@Composable
+fun OrbitToolTip(
+    backgroundColor: Color = OrbitTheme.colors.gray_900,
+    textColor: Color = OrbitTheme.colors.gray_100,
+    textStyle: TextStyle = OrbitTheme.typography.label2SemiBold,
+    offset: IntOffset = IntOffset(0, 0),
+    text: String,
+) {
+    val popupOffset = IntOffset(
+        x = offset.x + 15.dp.toRoundPx(),
+        y = offset.y + 2.dp.toRoundPx(),
+    )
+
+    Popup(
+        alignment = Alignment.Center,
+        offset = popupOffset,
+    ) {
+        Column(
+            horizontalAlignment = Alignment.Start,
+        ) {
+            Row {
+                Spacer(modifier = Modifier.width(15.dp))
+
+                Spacer(
+                    modifier = Modifier
+                        .width(10.dp)
+                        .height(5.dp)
+                        .background(
+                            color = backgroundColor,
+                            shape = RoundedTopTriangleShape(1.dp.toPx()),
+                        ),
+                )
+            }
+
+            Surface(
+                shape = RoundedCornerShape(8.dp),
+                color = backgroundColor,
+            ) {
+                Text(
+                    modifier = Modifier.padding(
+                        vertical = 6.dp,
+                        horizontal = 10.dp,
+                    ),
+                    text = text,
+                    style = textStyle,
+                    color = textColor,
+                )
+            }
+        }
+    }
+}
+
+class RoundedTopTriangleShape(private val radius: Float) : Shape {
+    override fun createOutline(
+        size: Size,
+        layoutDirection: LayoutDirection,
+        density: Density,
+    ): Outline {
+        val path = Path().apply {
+            val topX = size.width / 2f
+            val topY = 0f
+            val bottomLeftX = 0f
+            val bottomLeftY = size.height
+            val bottomRightX = size.width
+            val bottomRightY = size.height
+
+            // 왼쪽 아래 꼭짓점 시작
+            moveTo(bottomLeftX, bottomLeftY)
+
+            lineTo(topX - radius, topY)
+
+            arcTo(
+                rect = Rect(
+                    left = topX - radius,
+                    top = topY,
+                    right = topX + radius,
+                    bottom = topY + (2 * radius),
+                ),
+                startAngleDegrees = 180f,
+                sweepAngleDegrees = 180f,
+                forceMoveTo = false,
+            )
+
+            lineTo(bottomRightX, bottomRightY)
+
+            close()
+        }
+
+        return Outline.Generic(path)
+    }
+}
+
+@Preview
+@Composable
+fun ReversedPopup() {
+    OrbitTheme {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(Color.Gray),
+        ) {
+            Box(
+                modifier = Modifier.align(Alignment.Center),
+            ) {
+                Box(
+                    modifier = Modifier
+                        .size(32.dp)
+                        .clip(CircleShape)
+                        .clickable {},
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Icon(
+                        painter = painterResource(id = core.designsystem.R.drawable.ic_mail),
+                        contentDescription = "Mail",
+                        tint = OrbitTheme.colors.white,
+                    )
+                }
+
+                OrbitToolTip(
+                    text = "운세 도착",
+                    offset = IntOffset(x = 0, y = 32.dp.toRoundPx()),
+                )
+            }
+        }
+    }
+}

--- a/core/ui/src/main/java/com/yapp/ui/utils/DpToPx.kt
+++ b/core/ui/src/main/java/com/yapp/ui/utils/DpToPx.kt
@@ -8,3 +8,8 @@ import androidx.compose.ui.unit.Dp
 fun Dp.toPx(): Float {
     return with(LocalDensity.current) { this@toPx.toPx() }
 }
+
+@Composable
+fun Dp.toRoundPx(): Int {
+    return with(LocalDensity.current) { this@toRoundPx.roundToPx() }
+}

--- a/feature/home/src/main/java/com/yapp/home/HomeContract.kt
+++ b/feature/home/src/main/java/com/yapp/home/HomeContract.kt
@@ -17,6 +17,8 @@ sealed class HomeContract {
         val isDeleteDialogVisible: Boolean = false,
         val isNoActivatedAlarmDialogVisible: Boolean = false,
         val isNoDailyFortuneDialogVisible: Boolean = false,
+        val hasNewFortune: Boolean = false,
+        val isToolTipVisible: Boolean = false,
         val pendingAlarmToggle: Pair<Long, Boolean>? = null,
         val lastFortuneScore: Int = -1,
         val deliveryTime: String = "받을 수 있는 운세가 없어요",
@@ -41,6 +43,7 @@ sealed class HomeContract {
         data object HideNoActivatedAlarmDialog : Action()
         data object ShowNoDailyFortuneDialog : Action()
         data object HideNoDailyFortuneDialog : Action()
+        data object HideToolTip : Action()
         data object RollbackPendingAlarmToggle : Action()
         data object ConfirmDeletion : Action()
         data class DeleteSingleAlarm(val alarmId: Long) : Action()

--- a/feature/home/src/main/java/com/yapp/home/HomeScreen.kt
+++ b/feature/home/src/main/java/com/yapp/home/HomeScreen.kt
@@ -54,6 +54,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -63,6 +64,7 @@ import com.yapp.home.component.bottomsheet.AlarmListBottomSheet
 import com.yapp.ui.component.dialog.OrbitDialog
 import com.yapp.ui.component.lottie.LottieAnimation
 import com.yapp.ui.component.snackbar.showCustomSnackBar
+import com.yapp.ui.component.tooltip.OrbitToolTip
 import com.yapp.ui.utils.heightForScreenPercentage
 import com.yapp.ui.utils.toPx
 import feature.home.R
@@ -167,6 +169,8 @@ fun HomeScreen(
             onAddClick = {
                 eventDispatcher(HomeContract.Action.NavigateToAlarmCreation)
             },
+            hasNewFortune = state.hasNewFortune,
+            isTooltipVisible = state.isToolTipVisible,
         )
     } else {
         HomeContent(
@@ -262,7 +266,14 @@ private fun HomeContent(
         }
     }
 
-    Box {
+    Box(
+        modifier = Modifier.clickable(
+            interactionSource = remember { MutableInteractionSource() },
+            indication = null,
+        ) {
+            eventDispatcher(HomeContract.Action.HideToolTip)
+        },
+    ) {
         AlarmListBottomSheet(
             alarms = state.alarms,
             menuExpanded = state.dropdownMenuExpanded,
@@ -345,6 +356,8 @@ private fun HomeContent(
                 HomeTopBar(
                     onSettingClick = { eventDispatcher(HomeContract.Action.NavigateToSetting) },
                     onMailClick = { eventDispatcher(HomeContract.Action.ShowDailyFortune) },
+                    hasNewFortune = state.hasNewFortune,
+                    isShowTooltip = state.isToolTipVisible,
                 )
             }
         }
@@ -370,6 +383,8 @@ private fun HomeContent(
 private fun HomeTopBar(
     onSettingClick: () -> Unit,
     onMailClick: () -> Unit,
+    hasNewFortune: Boolean,
+    isShowTooltip: Boolean,
 ) {
     Box(
         modifier = Modifier.statusBarsPadding(),
@@ -383,20 +398,48 @@ private fun HomeTopBar(
         ) {
             Spacer(modifier = Modifier.weight(1f))
 
-            Box(
-                modifier = Modifier
-                    .size(32.dp)
-                    .clip(CircleShape)
-                    .clickable {
-                        onMailClick()
-                    },
-                contentAlignment = Alignment.Center,
-            ) {
-                Icon(
-                    painter = painterResource(id = core.designsystem.R.drawable.ic_mail),
-                    contentDescription = "Mail",
-                    tint = OrbitTheme.colors.white,
-                )
+            Box {
+                Box(
+                    contentAlignment = Alignment.BottomEnd,
+                ) {
+                    Box(
+                        modifier = Modifier
+                            .size(32.dp)
+                            .clip(CircleShape)
+                            .clickable {
+                                onMailClick()
+                            },
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        Icon(
+                            painter = painterResource(id = core.designsystem.R.drawable.ic_mail),
+                            contentDescription = "Mail",
+                            tint = OrbitTheme.colors.white,
+                        )
+                    }
+
+                    if (hasNewFortune) {
+                        Spacer(
+                            modifier = Modifier
+                                .size(7.dp)
+                                .background(
+                                    color = OrbitTheme.colors.alert,
+                                    shape = CircleShape,
+                                )
+                                .padding(
+                                    end = 4.dp,
+                                    bottom = 6.dp,
+                                ),
+                        )
+                    }
+                }
+
+                if (isShowTooltip) {
+                    OrbitToolTip(
+                        text = stringResource(id = R.string.home_tool_tip_fortune_arrived),
+                        offset = IntOffset(x = 0, y = 32.dp.toPx().toInt()),
+                    )
+                }
             }
 
             Spacer(modifier = Modifier.width(12.dp))
@@ -583,6 +626,8 @@ private fun HomeAlarmEmptyScreen(
     onSettingClick: () -> Unit,
     onMailClick: () -> Unit,
     onAddClick: () -> Unit,
+    hasNewFortune: Boolean,
+    isTooltipVisible: Boolean,
 ) {
     Column(
         modifier = Modifier
@@ -593,6 +638,8 @@ private fun HomeAlarmEmptyScreen(
         HomeTopBar(
             onSettingClick = onSettingClick,
             onMailClick = onMailClick,
+            hasNewFortune = hasNewFortune,
+            isShowTooltip = isTooltipVisible,
         )
 
         Spacer(modifier = Modifier.heightForScreenPercentage(0.13f))

--- a/feature/home/src/main/java/com/yapp/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/yapp/home/HomeViewModel.kt
@@ -398,18 +398,18 @@ class HomeViewModel @Inject constructor(
             combine(
                 userPreferences.fortuneDateFlow,
                 userPreferences.fortuneScoreFlow,
-                userPreferences.hasNewFortuneFlow
+                userPreferences.hasNewFortuneFlow,
             ) { fortuneDate, fortuneScore, hasNewFortune ->
                 val isTodayFortuneAvailable = fortuneDate == todayDate
                 val finalFortuneScore = if (isTodayFortuneAvailable) fortuneScore ?: -1 else -1
 
-                Triple(finalFortuneScore, hasNewFortune, isTodayFortuneAvailable)
-            }.collect { (finalFortuneScore, hasNewFortune, isTodayFortuneAvailable) -> // ✅ 수집 후 상태 업데이트
+                Pair(finalFortuneScore, hasNewFortune)
+            }.collect { (finalFortuneScore, hasNewFortune) ->
                 updateState {
                     copy(
                         lastFortuneScore = finalFortuneScore,
                         hasNewFortune = hasNewFortune,
-                        isToolTipVisible = hasNewFortune
+                        isToolTipVisible = hasNewFortune,
                     )
                 }
             }

--- a/feature/home/src/main/java/com/yapp/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/yapp/home/HomeViewModel.kt
@@ -15,6 +15,7 @@ import com.yapp.domain.usecase.AlarmUseCase
 import com.yapp.ui.base.BaseViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import feature.home.R
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
 import java.time.LocalDate
@@ -34,7 +35,7 @@ class HomeViewModel @Inject constructor(
 ) {
     init {
         loadAllAlarms()
-        loadDailyFortuneScore()
+        loadDailyFortuneState()
         loadUserName()
     }
 
@@ -52,6 +53,7 @@ class HomeViewModel @Inject constructor(
             HomeContract.Action.HideNoActivatedAlarmDialog -> hideNoActivatedAlarmDialog()
             HomeContract.Action.ShowNoDailyFortuneDialog -> showNoDailyFortuneDialog()
             HomeContract.Action.HideNoDailyFortuneDialog -> hideNoDailyFortuneDialog()
+            HomeContract.Action.HideToolTip -> hideToolTip()
             HomeContract.Action.RollbackPendingAlarmToggle -> rollbackAlarmActivation()
             HomeContract.Action.ConfirmDeletion -> confirmDeletion()
             is HomeContract.Action.DeleteSingleAlarm -> deleteSingleAlarm(action.alarmId)
@@ -381,6 +383,7 @@ class HomeViewModel @Inject constructor(
             if (fortuneDate != todayDate) {
                 processAction(HomeContract.Action.ShowNoDailyFortuneDialog)
             } else {
+                userPreferences.markFortuneAsChecked()
                 emitSideEffect(
                     HomeContract.SideEffect.Navigate(FortuneDestination.Fortune.route),
                 )
@@ -388,21 +391,26 @@ class HomeViewModel @Inject constructor(
         }
     }
 
-    private fun loadDailyFortuneScore() {
+    private fun loadDailyFortuneState() {
         viewModelScope.launch {
-            userPreferences.fortuneDateFlow.collect { fortuneDate ->
-                val todayDate = LocalDate.now().format(DateTimeFormatter.ISO_DATE)
+            val todayDate = LocalDate.now().format(DateTimeFormatter.ISO_DATE)
 
-                if (fortuneDate != todayDate) {
-                    updateState {
-                        currentState.copy(lastFortuneScore = -1)
-                    }
-                } else {
-                    userPreferences.fortuneScoreFlow.collect { score ->
-                        updateState {
-                            currentState.copy(lastFortuneScore = score ?: -1)
-                        }
-                    }
+            combine(
+                userPreferences.fortuneDateFlow,
+                userPreferences.fortuneScoreFlow,
+                userPreferences.hasNewFortuneFlow
+            ) { fortuneDate, fortuneScore, hasNewFortune ->
+                val isTodayFortuneAvailable = fortuneDate == todayDate
+                val finalFortuneScore = if (isTodayFortuneAvailable) fortuneScore ?: -1 else -1
+
+                Triple(finalFortuneScore, hasNewFortune, isTodayFortuneAvailable)
+            }.collect { (finalFortuneScore, hasNewFortune, isTodayFortuneAvailable) -> // ✅ 수집 후 상태 업데이트
+                updateState {
+                    copy(
+                        lastFortuneScore = finalFortuneScore,
+                        hasNewFortune = hasNewFortune,
+                        isToolTipVisible = hasNewFortune
+                    )
                 }
             }
         }
@@ -424,6 +432,10 @@ class HomeViewModel @Inject constructor(
         updateState { copy(isNoDailyFortuneDialogVisible = false) }
     }
 
+    private fun hideToolTip() {
+        updateState { copy(isToolTipVisible = false) }
+    }
+
     private fun navigateToSetting() {
         emitSideEffect(
             HomeContract.SideEffect.Navigate(
@@ -431,45 +443,4 @@ class HomeViewModel @Inject constructor(
             ),
         )
     }
-
-    /*
-    private fun loadMoreAlarms() {
-        val currentPage = currentState.paginationState.currentPage
-        if (currentState.paginationState.isLoading || !currentState.paginationState.hasMoreData) return
-
-        val pageSize = 10
-        val offset = currentPage * pageSize
-
-        updateState {
-            copy(
-                paginationState = currentState.paginationState.copy(isLoading = true),
-            )
-        }
-
-        viewModelScope.launch {
-            alarmUseCase.getPagedAlarms(limit = pageSize, offset = offset)
-                .onSuccess {
-                    updateState {
-                        copy(
-                            alarms = currentState.alarms + it,
-                            paginationState = currentState.paginationState.copy(
-                                currentPage = currentPage + 1,
-                                isLoading = false,
-                                hasMoreData = it.size == pageSize,
-                            ),
-                            initialLoading = false,
-                        )
-                    }
-                }
-                .onFailure {
-                    Log.e("HomeViewModel", "Failed to get paged alarms", it)
-                    updateState {
-                        copy(
-                            paginationState = currentState.paginationState.copy(isLoading = false),
-                            initialLoading = false,
-                        )
-                    }
-                }
-        }
-    }*/
 }

--- a/feature/home/src/main/res/values/strings.xml
+++ b/feature/home/src/main/res/values/strings.xml
@@ -4,6 +4,8 @@
     <string name="home_empty_title">기상 알람이 없어요</string>
     <string name="home_empty_description">알람을 추가하고\n운세 편지를 받아보세요</string>
 
+    <string name="home_tool_tip_fortune_arrived">운세 도착</string>
+
     <string name="home_fortune_no_alarm_description">운세 편지를 받고 싶다면\n기상 알람을 켜줘</string>
     <string name="home_fortune_preload_description">미래에서 운세 편지를\n작성 중이야!</string>
     <string name="home_fortune_0_to_49_description">오늘 %s의 하루는\n주의가 필요해</string>


### PR DESCRIPTION
## Related issue 🛠
[//]: # (해당하는 이슈 번호 달아주기)
closed #162 

어떤 변경사항이 있었나요?
- [ ] 🐞 BugFix Something isn't working
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [x] ✨ Feature Feature
- [ ] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (Junit, etc.)

## CheckPoint ✅
[//]: # (PR 요구사항 확인)
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 컨벤션에 맞게 작성했습니다. (필수)
- [x] merge할 브랜치의 위치를 확인해 주세요(main❌/develop⭕) (필수)
- [x] Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다. (필수)
- [ ] BugFix의 경우, 버그의 원인을 파악하였습니다. (선택)

## Work Description ✏️
[//]: # (작업 내용 간단 소개)

https://github.com/user-attachments/assets/305f4dd4-0e92-462e-8aab-4218583573d4

```kotlin
val hasNewFortuneFlow: Flow<Boolean> = dataStore.data
    .catch { emit(emptyPreferences()) }
    .map { preferences ->
        val savedDate = preferences[Keys.FORTUNE_DATE]
        val isChecked = preferences[Keys.FORTUNE_CHECKED] ?: true
        val todayDate = LocalDate.now().format(DateTimeFormatter.ISO_DATE)
        savedDate == todayDate && !isChecked
    }
    .distinctUntilChanged()

suspend fun saveFortuneId(fortuneId: Long) {
    val currentDate = LocalDate.now().format(DateTimeFormatter.ISO_DATE)
    dataStore.edit { preferences ->
        preferences[Keys.FORTUNE_ID] = fortuneId
        preferences[Keys.FORTUNE_DATE] = currentDate
        preferences[Keys.FORTUNE_CHECKED] = false
    }
}
```
운세 생성 (saveFortuenId) 시에 `FORTUNE_CHECKED` 값을 false로 설정
`hasNewFortuneFlow` 는 `FORTUNE_CHECKED` 값이 true이고 저장날짜가 오늘과 동일할 때만 true
홈 화면에서 `메일` 버튼을 클릭해서 운세로 갈 때 `FORTUNE_CHECKED` 를 false로 설정

## Uncompleted Tasks 😅
[//]: # (없다면 N/A)
N/A

## To Reviewers 📢
[//]: # (reviewer가 알면 좋은 내용들)
![image](https://github.com/user-attachments/assets/3d9063d5-d7c0-40b5-a74c-7737cd9139b4)