### PR TITLE
[BUGFIX] 스와이프로 알람 삭제 시 알람 해제 불가능 현상을 해결한다. #165

### DIFF
--- a/core/alarm/src/main/java/com/yapp/alarm/receivers/AlarmReceiver.kt
+++ b/core/alarm/src/main/java/com/yapp/alarm/receivers/AlarmReceiver.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.content.Intent
 import android.os.Build
 import android.util.Log
+import android.widget.Toast
 import com.yapp.alarm.AlarmConstants
 import com.yapp.alarm.AlarmHelper
 import com.yapp.alarm.services.AlarmService
@@ -38,14 +39,17 @@ class AlarmReceiver : BroadcastReceiver() {
                     @Suppress("DEPRECATION")
                     intent.getParcelableExtra(AlarmConstants.EXTRA_ALARM)
                 }
-
                 alarm?.let { handleSnooze(context, it) }
+
+                Toast.makeText(context, "알람이 ${alarm?.snoozeInterval}분 후 다시 울려요", Toast.LENGTH_SHORT).show()
             }
 
             AlarmConstants.ACTION_ALARM_DISMISSED -> {
                 Log.d("AlarmReceiver", "Alarm Dismissed")
                 context.stopService(alarmServiceIntent)
                 sendBroadCastToCloseAlarmInteractionActivity(context)
+
+                Toast.makeText(context, "알람이 해제되었어요", Toast.LENGTH_SHORT).show()
             }
         }
     }

--- a/core/alarm/src/main/java/com/yapp/alarm/services/AlarmService.kt
+++ b/core/alarm/src/main/java/com/yapp/alarm/services/AlarmService.kt
@@ -184,6 +184,9 @@ class AlarmService : Service() {
             .setPriority(NotificationCompat.PRIORITY_HIGH)
             .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
             .setFullScreenIntent(alarmAlertPendingIntent, true)
+            .setDeleteIntent(
+                snoozePendingIntent ?: alarmDismissPendingIntent,
+            )
             .addAction(core.designsystem.R.drawable.ic_cancel, "알람 해제", alarmDismissPendingIntent)
 
         snoozePendingIntent?.let {


### PR DESCRIPTION
## Related issue 🛠
[//]: # (해당하는 이슈 번호 달아주기)
closed #165 

어떤 변경사항이 있었나요?
- [x] 🐞 BugFix Something isn't working
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [ ] ✨ Feature Feature
- [ ] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (Junit, etc.)

## CheckPoint ✅
[//]: # (PR 요구사항 확인)
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 컨벤션에 맞게 작성했습니다. (필수)
- [x] merge할 브랜치의 위치를 확인해 주세요(main❌/develop⭕) (필수)
- [x] Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다. (필수)
- [x] BugFix의 경우, 버그의 원인을 파악하였습니다. (선택)

## Work Description ✏️
[//]: # (작업 내용 간단 소개)

https://github.com/user-attachments/assets/09c23331-efc2-43f5-b55e-a6dc4e47cb26

현재 안드로이드에서 알람(Notification)을 해제할 수 있는 방법은 다음과 같습니다:

1. 푸시 알람의 "알람 해제" 버튼을 누름  
2. 푸시 알람을 눌러 알람 해제 화면으로 이동 후 "알람 끄기" 버튼을 누름  

그러나, 사용자가 알람을 단순히 스와이프하여 제거할 경우  
알람이 계속 울리지만, 이를 끌 수 있는 방법이 없어지는 문제가 발생합니다.

### 문제점
- 단순히 스와이프하여 알람을 끌 수 없으며, 알람이 계속 울림  
- 안드로이드 14(API 34)부터 `setOngoing(true)`를 설정해도 알람을 스와이프할 수 있음  
  - [관련 문서](https://developer.android.com/about/versions/14/behavior-changes-all?hl=ko#non-dismissable-notifications)  
- 기존 알람 앱을 조사한 결과, 스와이프 시 "미루기(Snooze)" 동작을 수행하는 방식이 일반적  

### 해결 방법: 스와이프해서 알람 삭제 시 "미루기(Snooze)" 또는 "해제(Dismiss)"로 처리
사용자가 알람을 스와이프할 경우, 다음과 같이 처리합니다.

1. 알람을 미룰 수 있는 경우 (Snooze 가능)  
   - 스와이프 시 알람을 자동으로 미룸  
   - 설정된 스누즈 시간이 지나면 알람이 다시 울림  

2. 알람을 미룰 수 없는 경우 (Snooze 불가능)  
   - 스와이프 시 알람을 즉시 해제(Dismiss)  
   - 알람이 완전히 종료되며 다시 울리지 않음  

## Uncompleted Tasks 😅
[//]: # (없다면 N/A)
N/A

## To Reviewers 📢
[//]: # (reviewer가 알면 좋은 내용들)
![image](https://github.com/user-attachments/assets/3d9063d5-d7c0-40b5-a74c-7737cd9139b4)