### PR TITLE
[FIX] 흔들기 미션 시작 시 탭 미션이 잠깐 동안 나왔다가 사라는 문제를 해결합니다.

### DIFF
--- a/feature/mission/src/main/java/com/yapp/mission/MissionContract.kt
+++ b/feature/mission/src/main/java/com/yapp/mission/MissionContract.kt
@@ -6,6 +6,7 @@ sealed class MissionContract {
 
     data class State(
         val missionType: MissionType = MissionType.Click,
+        val isMissionTypeLoading: Boolean = true,
         val showOverlayText: Boolean = false,
         val showOverlay: Boolean = true,
         val missionProgress: Int = 0,

--- a/feature/mission/src/main/java/com/yapp/mission/MissionScreen.kt
+++ b/feature/mission/src/main/java/com/yapp/mission/MissionScreen.kt
@@ -67,7 +67,7 @@ fun MissionScreen(
     Box(
         modifier = Modifier.fillMaxSize(),
     ) {
-        if(state.isMissionTypeLoading) {
+        if (state.isMissionTypeLoading) {
             MissionLoadingScreen()
             return
         }

--- a/feature/mission/src/main/java/com/yapp/mission/MissionScreen.kt
+++ b/feature/mission/src/main/java/com/yapp/mission/MissionScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -32,6 +33,7 @@ import com.yapp.designsystem.theme.OrbitTheme
 import com.yapp.domain.model.MissionType
 import com.yapp.ui.component.button.OrbitButton
 import com.yapp.ui.component.dialog.OrbitDialog
+import com.yapp.ui.component.lottie.LottieAnimation
 import com.yapp.ui.utils.heightForScreenPercentage
 
 @Composable
@@ -65,6 +67,10 @@ fun MissionScreen(
     Box(
         modifier = Modifier.fillMaxSize(),
     ) {
+        if(state.isMissionTypeLoading) {
+            MissionLoadingScreen()
+            return
+        }
         Image(
             painter = painterResource(id = core.designsystem.R.drawable.img_mission_main_background),
             contentDescription = null,
@@ -196,7 +202,21 @@ fun MissionLabel(
 }
 
 @Composable
-@Preview
+fun MissionLoadingScreen() {
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center,
+    ) {
+        LottieAnimation(
+            modifier = Modifier
+                .size(70.dp),
+            resId = core.designsystem.R.raw.star_loading,
+        )
+    }
+}
+
+@Composable
+@Preview(showBackground = true)
 fun MissionRoutePreview() {
     MissionScreen(
         stateProvider = { MissionContract.State() },

--- a/feature/mission/src/main/java/com/yapp/mission/MissionViewModel.kt
+++ b/feature/mission/src/main/java/com/yapp/mission/MissionViewModel.kt
@@ -48,7 +48,10 @@ class MissionViewModel @Inject constructor(
     private fun loadRemoteMissionType() {
         viewModelScope.launch {
             val missionType = getMissionTypeUseCase.execute()
-            updateState { copy(missionType = missionType) }
+            updateState { copy(
+                missionType = missionType,
+                isMissionTypeLoading = false,
+            ) }
         }
     }
 

--- a/feature/mission/src/main/java/com/yapp/mission/MissionViewModel.kt
+++ b/feature/mission/src/main/java/com/yapp/mission/MissionViewModel.kt
@@ -48,10 +48,12 @@ class MissionViewModel @Inject constructor(
     private fun loadRemoteMissionType() {
         viewModelScope.launch {
             val missionType = getMissionTypeUseCase.execute()
-            updateState { copy(
-                missionType = missionType,
-                isMissionTypeLoading = false,
-            ) }
+            updateState {
+                copy(
+                    missionType = missionType,
+                    isMissionTypeLoading = false,
+                )
+            }
         }
     }
 


### PR DESCRIPTION
## Related issue 🛠
[//]: # (해당하는 이슈 번호 달아주기)
closed #211

어떤 변경사항이 있었나요?
- [x] 🐞 BugFix Something isn't working
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [ ] ✨ Feature Feature
- [x] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (Junit, etc.)

## CheckPoint ✅
[//]: # (PR 요구사항 확인)
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 컨벤션에 맞게 작성했습니다. (필수)
- [x] merge할 브랜치의 위치를 확인해 주세요(main❌/develop⭕) (필수)
- [x] Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다. (필수)
- [x] BugFix의 경우, 버그의 원인을 파악하였습니다. (선택)

## Work Description ✏️
[//]: # (작업 내용 간단 소개)
- 미션 타입의 기본값이 Click 으로 되어있어 RemoteConfig fetch를 하는동안 Click미션의 UX가 노출되는 문제 해결
  - isMissionTypeLoading 상태를 추가하여 fetch 가 끝날 때 false로 처리하여 미션정보를 가져오는 동안 로딩화면 노출

## Uncompleted Tasks 😅
[//]: # (없다면 N/A)
- [ ] Task1

## To Reviewers 📢
[//]: # (reviewer가 알면 좋은 내용들)
