### PR TITLE
[SETTING] 빌드 환경에 따라 applicationId를 분기합니다.

### DIFF
--- a/.github/workflows/android_cd.yml
+++ b/.github/workflows/android_cd.yml
@@ -45,13 +45,19 @@ jobs:
             - name: Install Firebase CLI
               run: curl -sL https://firebase.tools | bash
 
-            # 6. Decode google-services.json
-            - name: Decode google-services.json
+            # 6. Decode google-services.json for debug
+            - name: Decode google-services.json (debug)
               env:
-                  FIREBASE_SECRET: ${{ secrets.FIREBASE_SECRET }}
+                FIREBASE_SECRET: ${{ secrets.FIREBASE_SECRET_DEBUG }}
+              run: echo $FIREBASE_SECRET | base64 --decode > app/src/dev/google-services.json
+
+            # 7. Decode google-services.json for release
+            - name: Decode google-services.json (release)
+              env:
+                FIREBASE_SECRET: ${{ secrets.FIREBASE_SECRET_RELEASE }}
               run: echo $FIREBASE_SECRET | base64 --decode > app/google-services.json
 
-            # Add Local Properties
+            # 8. Add Local Properties
             - name: Add Local Properties
               env:
                   BASE_URL: ${{ secrets.BASE_URL }}
@@ -68,41 +74,41 @@ jobs:
                   echo -e "admobAdUnitIdDebug=$ADMOB_AD_UNIT_ID_DEBUG" >> local.properties
                   echo -e "admobAdUnitIdRelease=$ADMOB_AD_UNIT_ID_RELEASE" >> local.properties
 
-            # 7. Debug Local Properties Check
-            -   name: Debug Local Properties
-                run: cat local.properties
+            # 9. Debug Local Properties Check
+            - name: Debug Local Properties
+              run: cat local.properties
 
-            # 8. Ktlint
+            # 10. Ktlint
             - name: Run Ktlint Check
               run: ./gradlew ktlintCheck --stacktrace
 
-            # 9. Debug APK Build
+            # 11. Debug APK Build
             - name: Build Debug APK
               run: ./gradlew assembleDebug --stacktrace
 
-            # 10. Release AAB Build
+            # 12. Release AAB Build
             - name: Build Release AAB
               run: ./gradlew bundleRelease --stacktrace
 
-            # 11. Release APK Build
+            # 13. Release APK Build
             - name: Build Release APK
               run: ./gradlew assembleRelease --stacktrace
 
-            # 12. AAB Artifact Upload
+            # 14. AAB Artifact Upload
             - name: Upload Release AAB
               uses: actions/upload-artifact@v4
               with:
                   name: release-aab
                   path: app/build/outputs/bundle/release/app-release.aab
 
-            # 13. APK Artifact Upload
+            # 15. APK Artifact Upload
             - name: Upload Release APK
               uses: actions/upload-artifact@v4
               with:
                   name: release-apk
                   path: app/build/outputs/apk/release/app-release.apk
 
-            # 14. Set up Firebase Service Account Credentials
+            # 16. Set up Firebase Service Account Credentials
             - name: Set up Firebase Service Account Credentials
               env:
                   GOOGLE_APPLICATION_CREDENTIALS_JSON: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS_JSON }}
@@ -113,7 +119,7 @@ jobs:
                   export GOOGLE_APPLICATION_CREDENTIALS=$HOME/firebase-credentials.json
                   echo "GOOGLE_APPLICATION_CREDENTIALS=$GOOGLE_APPLICATION_CREDENTIALS"
 
-            # 15. Firebase CLI 인증 확인
+            # 17. Firebase CLI 인증 확인
             - name: Check Firebase CLI Authentication
               run: |
                   export GOOGLE_APPLICATION_CREDENTIALS=$HOME/firebase-credentials.json
@@ -125,7 +131,7 @@ jobs:
                   echo "📌 현재 Firebase 프로젝트 목록 확인:"
                   firebase projects:list || (echo "❌ Firebase 인증 실패!"; exit 1)
 
-            # 16. Firebase App Distribution Upload
+            # 18. Firebase App Distribution Upload
             - name: Upload APK to Firebase App Distribution
               env:
                   GOOGLE_APPLICATION_CREDENTIALS: $HOME/firebase-credentials.json
@@ -148,7 +154,7 @@ jobs:
                   --release-notes "🚀 새로운 데모 버전이 배포되었습니다!" \
                   --groups "orbit-tester-group"
 
-            # 17. Notify Discord
+            # 19. Notify Discord
             - name: Notify Discord
               env:
                   DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}

--- a/.github/workflows/android_cd.yml
+++ b/.github/workflows/android_cd.yml
@@ -49,7 +49,9 @@ jobs:
             - name: Decode google-services.json (debug)
               env:
                 FIREBASE_SECRET: ${{ secrets.FIREBASE_SECRET_DEBUG }}
-              run: echo $FIREBASE_SECRET | base64 --decode > app/src/dev/google-services.json
+              run: |
+                mkdir -p app/src/dev
+                echo $FIREBASE_SECRET | base64 --decode > app/src/dev/google-services.json
 
             # 7. Decode google-services.json for release
             - name: Decode google-services.json (release)

--- a/.github/workflows/android_ci.yml
+++ b/.github/workflows/android_ci.yml
@@ -46,17 +46,15 @@ jobs:
       - name: Decode google-services.json (debug)
         env:
           FIREBASE_SECRET: ${{ secrets.FIREBASE_SECRET_DEBUG }}
-        run: echo $FIREBASE_SECRET | base64 --decode > app/src/dev/google-services.json
+        run: |
+          mkdir -p app/src/dev
+          echo $FIREBASE_SECRET | base64 --decode > app/src/dev/google-services.json
 
       # Decode google-services.json for release
       - name: Decode google-services.json (release)
         env:
           FIREBASE_SECRET: ${{ secrets.FIREBASE_SECRET_RELEASE }}
         run: echo $FIREBASE_SECRET | base64 --decode > app/google-services.json
-
-      # Debug google-services.json
-      - name: Debug google-services.json
-        run: cat app/google-services.json
 
       # Add Local Properties
       - name: Add Local Properties

--- a/.github/workflows/android_ci.yml
+++ b/.github/workflows/android_ci.yml
@@ -42,10 +42,16 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
-      # Decode google-services.json
-      - name: Decode google-services.json
+      # Decode google-services.json for debug
+      - name: Decode google-services.json (debug)
         env:
-          FIREBASE_SECRET: ${{ secrets.FIREBASE_SECRET }}
+          FIREBASE_SECRET: ${{ secrets.FIREBASE_SECRET_DEBUG }}
+        run: echo $FIREBASE_SECRET | base64 --decode > app/src/dev/google-services.json
+
+      # Decode google-services.json for release
+      - name: Decode google-services.json (release)
+        env:
+          FIREBASE_SECRET: ${{ secrets.FIREBASE_SECRET_RELEASE }}
         run: echo $FIREBASE_SECRET | base64 --decode > app/google-services.json
 
       # Debug google-services.json

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,6 +16,11 @@ android {
     }
 
     buildTypes {
+        debug {
+            applicationIdSuffix = ".dev"
+            isDebuggable = true
+        }
+
         release {
             signingConfig = signingConfigs.getByName("debug")
         }

--- a/app/src/debug/res/values/strings.xml
+++ b/app/src/debug/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name">오르비 알람 DEV</string>
+</resources>

--- a/core/alarm/src/main/java/com/yapp/alarm/pendingIntent/interaction/AlarmAlertPendingIntent.kt
+++ b/core/alarm/src/main/java/com/yapp/alarm/pendingIntent/interaction/AlarmAlertPendingIntent.kt
@@ -12,6 +12,7 @@ fun createAlarmAlertPendingIntent(
     alarm: Alarm,
 ): PendingIntent {
     val alarmAlertIntent = createAlarmAlertIntent(
+        context,
         alarm.id,
         alarm,
     )
@@ -24,6 +25,7 @@ fun createAlarmAlertPendingIntent(
 }
 
 private fun createAlarmAlertIntent(
+    context: Context,
     notificationId: Long,
     alarm: Alarm,
 ): Intent {
@@ -31,5 +33,6 @@ private fun createAlarmAlertIntent(
         putExtra(AlarmConstants.EXTRA_NOTIFICATION_ID, notificationId)
         putExtra(AlarmConstants.EXTRA_ALARM, alarm)
         addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP)
+        setPackage(context.packageName)
     }
 }

--- a/core/alarm/src/main/java/com/yapp/alarm/pendingIntent/interaction/AlarmDismissPendingIntent.kt
+++ b/core/alarm/src/main/java/com/yapp/alarm/pendingIntent/interaction/AlarmDismissPendingIntent.kt
@@ -5,7 +5,7 @@ import android.app.PendingIntent.FLAG_IMMUTABLE
 import android.app.PendingIntent.FLAG_UPDATE_CURRENT
 import android.content.Context
 import android.content.Intent
-import android.net.Uri
+import androidx.core.net.toUri
 import com.yapp.alarm.AlarmConstants
 import com.yapp.alarm.receivers.AlarmReceiver
 
@@ -36,7 +36,7 @@ fun createNavigateToMissionPendingIntent(
     applicationContext: Context,
     notificationId: Long,
 ): PendingIntent {
-    val navigateToMissionIntent = createNavigateToMissionIntent(notificationId)
+    val navigateToMissionIntent = createNavigateToMissionIntent(applicationContext, notificationId)
     return PendingIntent.getActivity(
         applicationContext,
         notificationId.toInt(),
@@ -46,9 +46,11 @@ fun createNavigateToMissionPendingIntent(
 }
 
 fun createNavigateToMissionIntent(
+    context: Context,
     notificationId: Long,
 ): Intent {
-    return Intent(Intent.ACTION_VIEW, Uri.parse("orbitapp://mission?notificationId=$notificationId")).apply {
+    return Intent(Intent.ACTION_VIEW, "orbitapp://mission?notificationId=$notificationId".toUri()).apply {
         addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
+        setPackage(context.packageName)
     }
 }

--- a/core/alarm/src/main/java/com/yapp/alarm/receivers/AlarmInteractionActivityReceiver.kt
+++ b/core/alarm/src/main/java/com/yapp/alarm/receivers/AlarmInteractionActivityReceiver.kt
@@ -3,9 +3,8 @@ package com.yapp.alarm.receivers
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
-import android.net.Uri
-import android.util.Log
 import androidx.activity.ComponentActivity
+import androidx.core.net.toUri
 import com.yapp.alarm.AlarmConstants
 import com.yapp.datastore.UserPreferences
 import dagger.hilt.android.AndroidEntryPoint
@@ -24,7 +23,6 @@ class AlarmInteractionActivityReceiver(private val activity: ComponentActivity) 
     lateinit var userPreferences: UserPreferences
 
     override fun onReceive(context: Context?, intent: Intent?) {
-        Log.d("AlarmInteractionActivityReceiver", "알람 수신, AlarmAlertActivity 종료")
         val isSnoozed = intent?.getBooleanExtra(AlarmConstants.EXTRA_IS_SNOOZED, false) ?: false
 
         if (intent?.action == AlarmConstants.ACTION_ALARM_INTERACTION_ACTIVITY_CLOSE) {
@@ -35,12 +33,10 @@ class AlarmInteractionActivityReceiver(private val activity: ComponentActivity) 
                     val fortuneDate = userPreferences.fortuneDateFlow.firstOrNull()
                     val todayDate = LocalDate.now().format(DateTimeFormatter.ISO_DATE)
 
-                    Log.d("AlarmReceiver", "fortuneDate: $fortuneDate, todayDate: $todayDate")
-
                     if (fortuneDate != todayDate) {
                         context?.let {
                             val missionIntent =
-                                Intent(Intent.ACTION_VIEW, Uri.parse("orbitapp://mission")).apply {
+                                Intent(Intent.ACTION_VIEW, "orbitapp://mission".toUri()).apply {
                                     addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
                                 }
                             it.startActivity(missionIntent)

--- a/core/alarm/src/main/java/com/yapp/alarm/receivers/AlarmInteractionActivityReceiver.kt
+++ b/core/alarm/src/main/java/com/yapp/alarm/receivers/AlarmInteractionActivityReceiver.kt
@@ -38,6 +38,7 @@ class AlarmInteractionActivityReceiver(private val activity: ComponentActivity) 
                             val missionIntent =
                                 Intent(Intent.ACTION_VIEW, "orbitapp://mission".toUri()).apply {
                                     addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                                    setPackage(context.packageName)
                                 }
                             it.startActivity(missionIntent)
                         }

--- a/core/alarm/src/main/java/com/yapp/alarm/services/AlarmService.kt
+++ b/core/alarm/src/main/java/com/yapp/alarm/services/AlarmService.kt
@@ -16,6 +16,7 @@ import android.os.Vibrator
 import android.os.VibratorManager
 import android.util.Log
 import androidx.core.app.NotificationCompat
+import androidx.core.net.toUri
 import com.yapp.alarm.AlarmConstants
 import com.yapp.alarm.AlarmHelper
 import com.yapp.alarm.pendingIntent.interaction.createAlarmAlertPendingIntent
@@ -221,7 +222,7 @@ class AlarmService : Service() {
 
     private fun startSound(soundUri: String, volume: Int) {
         val uri: Uri = if (soundUri.isNotEmpty()) {
-            Uri.parse(soundUri)
+            soundUri.toUri()
         } else {
             RingtoneManager.getDefaultUri(RingtoneManager.TYPE_ALARM)
         }

--- a/feature/setting/src/main/java/com/yapp/setting/SettingScreen.kt
+++ b/feature/setting/src/main/java/com/yapp/setting/SettingScreen.kt
@@ -1,7 +1,6 @@
 package com.yapp.setting
 
 import android.content.Intent
-import android.net.Uri
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -21,6 +20,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.core.net.toUri
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.yapp.designsystem.theme.OrbitTheme
@@ -55,7 +55,7 @@ fun SettingRoute(
             val kakaoUrl = "http://pf.kakao.com/_ykqxjn"
             val kakaoSchemeUrl = "kakaoplus://plusfriend/home/_ykqxjn"
 
-            val kakaoIntent = Intent(Intent.ACTION_VIEW, Uri.parse(kakaoSchemeUrl))
+            val kakaoIntent = Intent(Intent.ACTION_VIEW, kakaoSchemeUrl.toUri())
 
             try {
                 context.startActivity(kakaoIntent) // 카카오톡 앱으로 이동


### PR DESCRIPTION
## Related issue 🛠
[//]: # (해당하는 이슈 번호 달아주기)
closed #217 

어떤 변경사항이 있었나요?
- [ ] 🐞 BugFix Something isn't working
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [ ] ✨ Feature Feature
- [ ] 🔨 Refactor Code refactoring
- [x] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (Junit, etc.)

## CheckPoint ✅
[//]: # (PR 요구사항 확인)
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 컨벤션에 맞게 작성했습니다. (필수)
- [x] merge할 브랜치의 위치를 확인해 주세요(main❌/develop⭕) (필수)
- [x] Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다. (필수)
- [ ] BugFix의 경우, 버그의 원인을 파악하였습니다. (선택)

## Work Description ✏️
[//]: # (작업 내용 간단 소개)
- `build.gradle`에서 `debug` 빌드 타입에 대해 `applicationIdSuffix = ".dev"` 설정을 추가했습니다.
- 빌드 타입에 따라 앱 이름(`app_name`)을 `오르비 알람 DEV`와 `오르비 알람`으로 분기되도록 `resValue` 처리했습니다.
- 딥링크(Intent.ACTION_VIEW) 처리 시, 현재 앱이 debug 빌드인지 여부를 판단해 `.dev` 또는 기본 패키지로 `setPackage`를 분기 적용했습니다.
- CI에서 debug/release 빌드 타입에 맞게 `google-services.json`을 주입하도록 개선하였습니다.

## Uncompleted Tasks 😅
[//]: # (없다면 N/A)
N/A

## To Reviewers 📢
[//]: # (reviewer가 알면 좋은 내용들)
<img width="334" alt="image" src="https://github.com/user-attachments/assets/cf4541d3-99b4-4f4b-82d4-644bfb759d1d" />

<img width="649" alt="image" src="https://github.com/user-attachments/assets/156249d5-dcd0-447f-9649-21967e0b16fe" />

파이어베이스 콘솔에서 `google-services.json` 다시 다운받아서
release 빌드는 `app 폴더`에 dev 빌드는 `app/src/dev 폴더`에 넣으면 됩니다.




