### PR TITLE
[REFACTOR] 운세 생성 상태 관리용 FortuneCreateStatusFlow 도입

### DIFF
--- a/core/alarm/src/main/java/com/yapp/alarm/receivers/AlarmInteractionActivityReceiver.kt
+++ b/core/alarm/src/main/java/com/yapp/alarm/receivers/AlarmInteractionActivityReceiver.kt
@@ -46,12 +46,14 @@ class AlarmInteractionActivityReceiver(private val activity: ComponentActivity) 
                 CoroutineScope(Dispatchers.Main).launch {
                     try {
                         if (!hasValidMissionData) {
-                            val fortuneCreateStaus = withContext(Dispatchers.IO) {
-                                fortuneRepository.fortuneCreateStatusFlow.first()
+                            val (fortuneCreateStatus, hasUnseenFortune) = withContext(Dispatchers.IO) {
+                                val status = fortuneRepository.fortuneCreateStatusFlow.first()
+                                val unseen = fortuneRepository.hasUnseenFortuneFlow.first()
+                                status to unseen
                             }
 
-                            when (fortuneCreateStaus) {
-                                is FortuneCreateStatus.Creating, is FortuneCreateStatus.Success -> {
+                            when (fortuneCreateStatus) {
+                                is FortuneCreateStatus.Creating -> {
                                     context?.let { ctx ->
                                         val uri = "orbitapp://fortune".toUri()
                                         val fortuneIntent = Intent(Intent.ACTION_VIEW, uri).apply {
@@ -62,8 +64,21 @@ class AlarmInteractionActivityReceiver(private val activity: ComponentActivity) 
                                     }
                                 }
 
-                                FortuneCreateStatus.Failure, FortuneCreateStatus.Idle -> {
+                                is FortuneCreateStatus.Success -> {
+                                    if (hasUnseenFortune) {
+                                        context?.let { ctx ->
+                                            val uri = "orbitapp://fortune".toUri()
+                                            val fortuneIntent =
+                                                Intent(Intent.ACTION_VIEW, uri).apply {
+                                                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                                                    setPackage(ctx.packageName)
+                                                }
+                                            ctx.startActivity(fortuneIntent)
+                                        }
+                                    }
                                 }
+
+                                FortuneCreateStatus.Failure, FortuneCreateStatus.Idle -> { }
                             }
                         } else {
                             context?.let { ctx ->

--- a/core/alarm/src/main/java/com/yapp/alarm/receivers/AlarmInteractionActivityReceiver.kt
+++ b/core/alarm/src/main/java/com/yapp/alarm/receivers/AlarmInteractionActivityReceiver.kt
@@ -6,6 +6,7 @@ import android.content.Intent
 import androidx.activity.ComponentActivity
 import androidx.core.net.toUri
 import com.yapp.alarm.AlarmConstants
+import com.yapp.domain.model.FortuneCreateStatus
 import com.yapp.domain.model.MissionType
 import com.yapp.domain.repository.FortuneRepository
 import dagger.hilt.android.AndroidEntryPoint
@@ -45,31 +46,36 @@ class AlarmInteractionActivityReceiver(private val activity: ComponentActivity) 
                 CoroutineScope(Dispatchers.Main).launch {
                     try {
                         if (!hasValidMissionData) {
-                            val hasUnseenFortune = withContext(Dispatchers.IO) {
-                                fortuneRepository.hasUnseenFortuneFlow.first()
+                            val fortuneCreateStaus = withContext(Dispatchers.IO) {
+                                fortuneRepository.fortuneCreateStatusFlow.first()
                             }
-                            if (hasUnseenFortune) {
-                                context?.let { ctx ->
-                                    val uri = "orbitapp://fortune".toUri()
-                                    val fortuneIntent = Intent(Intent.ACTION_VIEW, uri).apply {
+
+                            when (fortuneCreateStaus) {
+                                is FortuneCreateStatus.Creating, is FortuneCreateStatus.Success -> {
+                                    context?.let { ctx ->
+                                        val uri = "orbitapp://fortune".toUri()
+                                        val fortuneIntent = Intent(Intent.ACTION_VIEW, uri).apply {
+                                            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                                            setPackage(ctx.packageName)
+                                        }
+                                        ctx.startActivity(fortuneIntent)
+                                    }
+                                }
+
+                                FortuneCreateStatus.Failure, FortuneCreateStatus.Idle -> {
+                                }
+                            }
+                        } else {
+                            context?.let { ctx ->
+                                val uriString =
+                                    "orbitapp://mission?notificationId=$notificationId&missionType=${missionType.value}&missionCount=$missionCount"
+                                val missionIntent =
+                                    Intent(Intent.ACTION_VIEW, uriString.toUri()).apply {
                                         addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
                                         setPackage(ctx.packageName)
                                     }
-                                    ctx.startActivity(fortuneIntent)
-                                }
+                                ctx.startActivity(missionIntent)
                             }
-                            return@launch
-                        }
-
-                        context?.let { ctx ->
-                            val uriString =
-                                "orbitapp://mission?notificationId=$notificationId&missionType=${missionType.value}&missionCount=$missionCount"
-                            val missionIntent =
-                                Intent(Intent.ACTION_VIEW, uriString.toUri()).apply {
-                                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                                    setPackage(ctx.packageName)
-                                }
-                            ctx.startActivity(missionIntent)
                         }
                     } finally {
                         pending.finish()

--- a/core/datastore/src/main/java/com/yapp/datastore/UserPreferences.kt
+++ b/core/datastore/src/main/java/com/yapp/datastore/UserPreferences.kt
@@ -131,20 +131,6 @@ class UserPreferences @Inject constructor(
         }
     }
 
-    suspend fun tryMarkFortuneCreating(): Boolean {
-        var canStart = false
-        dataStore.edit { pref ->
-            val hasTodayFortune = pref[Keys.FORTUNE_DATE] == today() && pref[Keys.FORTUNE_ID] != null
-            val creating = pref[Keys.FORTUNE_CREATING] ?: false
-            if (!hasTodayFortune && !creating) {
-                pref[Keys.FORTUNE_CREATING] = true
-                pref[Keys.FORTUNE_FAILED] = false
-                canStart = true
-            }
-        }
-        return canStart
-    }
-
     suspend fun markFortuneCreating() {
         dataStore.edit { pref ->
             pref[Keys.FORTUNE_CREATING] = true

--- a/data/src/main/java/com/yapp/data/local/datasource/FortuneLocalDataSource.kt
+++ b/data/src/main/java/com/yapp/data/local/datasource/FortuneLocalDataSource.kt
@@ -1,5 +1,6 @@
 package com.yapp.data.local.datasource
 
+import com.yapp.domain.model.FortuneCreateStatus
 import kotlinx.coroutines.flow.Flow
 
 interface FortuneLocalDataSource {
@@ -9,11 +10,10 @@ interface FortuneLocalDataSource {
     val fortuneScoreFlow: Flow<Int?>
     val hasUnseenFortuneFlow: Flow<Boolean>
     val shouldShowFortuneToolTipFlow: Flow<Boolean>
-    val isFortuneCreatingFlow: Flow<Boolean>
-    val isFortuneFailedFlow: Flow<Boolean>
     val isFirstAlarmDismissedTodayFlow: Flow<Boolean>
 
-    suspend fun tryMarkFortuneCreating(): Boolean
+    val fortuneCreateStatusFlow: Flow<FortuneCreateStatus>
+
     suspend fun markFortuneCreating()
     suspend fun markFortuneCreated(fortuneId: Long)
     suspend fun markFortuneFailed()

--- a/data/src/main/java/com/yapp/data/local/datasource/FortuneLocalDataSourceImpl.kt
+++ b/data/src/main/java/com/yapp/data/local/datasource/FortuneLocalDataSourceImpl.kt
@@ -1,6 +1,9 @@
 package com.yapp.data.local.datasource
 
 import com.yapp.datastore.UserPreferences
+import com.yapp.domain.model.FortuneCreateStatus
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
 import javax.inject.Inject
 
 class FortuneLocalDataSourceImpl @Inject constructor(
@@ -13,13 +16,20 @@ class FortuneLocalDataSourceImpl @Inject constructor(
     override val fortuneScoreFlow = userPreferences.fortuneScoreFlow
     override val hasUnseenFortuneFlow = userPreferences.hasUnseenFortuneFlow
     override val shouldShowFortuneToolTipFlow = userPreferences.shouldShowFortuneToolTipFlow
-    override val isFortuneCreatingFlow = userPreferences.isFortuneCreatingFlow
-    override val isFortuneFailedFlow = userPreferences.isFortuneFailedFlow
     override val isFirstAlarmDismissedTodayFlow = userPreferences.isFirstAlarmDismissedTodayFlow
 
-    override suspend fun tryMarkFortuneCreating(): Boolean {
-        return userPreferences.tryMarkFortuneCreating()
-    }
+    override val fortuneCreateStatusFlow = combine(
+        userPreferences.fortuneIdFlow,
+        userPreferences.isFortuneCreatingFlow,
+        userPreferences.isFortuneFailedFlow,
+    ) { fortuneId, isCreating, isFailed ->
+        when {
+            isCreating -> FortuneCreateStatus.Creating
+            isFailed -> FortuneCreateStatus.Failure
+            fortuneId != null -> FortuneCreateStatus.Success(fortuneId)
+            else -> FortuneCreateStatus.Idle
+        }
+    }.distinctUntilChanged()
 
     override suspend fun markFortuneCreating() {
         userPreferences.markFortuneCreating()

--- a/data/src/main/java/com/yapp/data/local/datasource/FortuneLocalDataSourceImpl.kt
+++ b/data/src/main/java/com/yapp/data/local/datasource/FortuneLocalDataSourceImpl.kt
@@ -4,6 +4,8 @@ import com.yapp.datastore.UserPreferences
 import com.yapp.domain.model.FortuneCreateStatus
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
 import javax.inject.Inject
 
 class FortuneLocalDataSourceImpl @Inject constructor(
@@ -20,16 +22,19 @@ class FortuneLocalDataSourceImpl @Inject constructor(
 
     override val fortuneCreateStatusFlow = combine(
         userPreferences.fortuneIdFlow,
+        userPreferences.fortuneDateFlow,
         userPreferences.isFortuneCreatingFlow,
         userPreferences.isFortuneFailedFlow,
-    ) { fortuneId, isCreating, isFailed ->
+    ) { fortuneId, fortuneDate, isCreating, isFailed ->
         when {
             isCreating -> FortuneCreateStatus.Creating
             isFailed -> FortuneCreateStatus.Failure
-            fortuneId != null -> FortuneCreateStatus.Success(fortuneId)
+            fortuneId != null && fortuneDate == today() -> FortuneCreateStatus.Success(fortuneId)
             else -> FortuneCreateStatus.Idle
         }
     }.distinctUntilChanged()
+
+    private fun today(): String = LocalDate.now().format(DateTimeFormatter.ISO_DATE)
 
     override suspend fun markFortuneCreating() {
         userPreferences.markFortuneCreating()

--- a/data/src/main/java/com/yapp/data/local/datasource/FortuneLocalDataSourceImpl.kt
+++ b/data/src/main/java/com/yapp/data/local/datasource/FortuneLocalDataSourceImpl.kt
@@ -27,8 +27,8 @@ class FortuneLocalDataSourceImpl @Inject constructor(
         userPreferences.isFortuneFailedFlow,
     ) { fortuneId, fortuneDate, isCreating, isFailed ->
         when {
-            isCreating -> FortuneCreateStatus.Creating
             isFailed -> FortuneCreateStatus.Failure
+            isCreating -> FortuneCreateStatus.Creating
             fortuneId != null && fortuneDate == today() -> FortuneCreateStatus.Success(fortuneId)
             else -> FortuneCreateStatus.Idle
         }

--- a/data/src/main/java/com/yapp/data/repositoryimpl/FortuneRepositoryImpl.kt
+++ b/data/src/main/java/com/yapp/data/repositoryimpl/FortuneRepositoryImpl.kt
@@ -4,6 +4,7 @@ import com.yapp.data.local.datasource.FortuneLocalDataSource
 import com.yapp.data.remote.datasource.FortuneDataSource
 import com.yapp.data.remote.dto.response.toDomain
 import com.yapp.domain.model.Fortune
+import com.yapp.domain.model.FortuneCreateStatus
 import com.yapp.domain.repository.FortuneRepository
 import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
@@ -19,11 +20,10 @@ class FortuneRepositoryImpl @Inject constructor(
     override val fortuneScoreFlow: Flow<Int?> = fortuneLocalDataSource.fortuneScoreFlow
     override val hasUnseenFortuneFlow: Flow<Boolean> = fortuneLocalDataSource.hasUnseenFortuneFlow
     override val shouldShowFortuneToolTipFlow: Flow<Boolean> = fortuneLocalDataSource.shouldShowFortuneToolTipFlow
-    override val isFortuneCreatingFlow: Flow<Boolean> = fortuneLocalDataSource.isFortuneCreatingFlow
-    override val isFortuneFailedFlow: Flow<Boolean> = fortuneLocalDataSource.isFortuneFailedFlow
     override val isFirstAlarmDismissedTodayFlow: Flow<Boolean> = fortuneLocalDataSource.isFirstAlarmDismissedTodayFlow
 
-    override suspend fun tryMarkFortuneCreating() = fortuneLocalDataSource.tryMarkFortuneCreating()
+    override val fortuneCreateStatusFlow: Flow<FortuneCreateStatus> = fortuneLocalDataSource.fortuneCreateStatusFlow
+
     override suspend fun markFortuneAsCreating() = fortuneLocalDataSource.markFortuneCreating()
     override suspend fun markFortuneAsCreated(fortuneId: Long) = fortuneLocalDataSource.markFortuneCreated(fortuneId)
     override suspend fun markFortuneAsFailed() = fortuneLocalDataSource.markFortuneFailed()

--- a/domain/src/main/java/com/yapp/domain/model/FortuneCreateStatus.kt
+++ b/domain/src/main/java/com/yapp/domain/model/FortuneCreateStatus.kt
@@ -1,0 +1,8 @@
+package com.yapp.domain.model
+
+sealed class FortuneCreateStatus {
+    data object Idle : FortuneCreateStatus()
+    data object Creating : FortuneCreateStatus()
+    data class Success(val fortuneId: Long) : FortuneCreateStatus()
+    data object Failure : FortuneCreateStatus()
+}

--- a/domain/src/main/java/com/yapp/domain/repository/FortuneRepository.kt
+++ b/domain/src/main/java/com/yapp/domain/repository/FortuneRepository.kt
@@ -1,6 +1,7 @@
 package com.yapp.domain.repository
 
 import com.yapp.domain.model.Fortune
+import com.yapp.domain.model.FortuneCreateStatus
 import kotlinx.coroutines.flow.Flow
 
 interface FortuneRepository {
@@ -10,11 +11,10 @@ interface FortuneRepository {
     val fortuneScoreFlow: Flow<Int?>
     val hasUnseenFortuneFlow: Flow<Boolean>
     val shouldShowFortuneToolTipFlow: Flow<Boolean>
-    val isFortuneCreatingFlow: Flow<Boolean>
-    val isFortuneFailedFlow: Flow<Boolean>
     val isFirstAlarmDismissedTodayFlow: Flow<Boolean>
 
-    suspend fun tryMarkFortuneCreating(): Boolean
+    val fortuneCreateStatusFlow: Flow<FortuneCreateStatus>
+
     suspend fun markFortuneAsCreating()
     suspend fun markFortuneAsCreated(fortuneId: Long)
     suspend fun markFortuneAsFailed()

--- a/feature/fortune/src/main/java/com/yapp/fortune/FortuneViewModel.kt
+++ b/feature/fortune/src/main/java/com/yapp/fortune/FortuneViewModel.kt
@@ -64,12 +64,8 @@ class FortuneViewModel @Inject constructor(
                     )
                 }
 
-                is FortuneCreateStatus.Failure -> {
-                    reduce { state.copy(isLoading = false) }
-                }
-
-                is FortuneCreateStatus.Idle -> {
-                    reduce { state.copy(isLoading = false) }
+                is FortuneCreateStatus.Failure, FortuneCreateStatus.Idle -> {
+                    postSideEffect(FortuneContract.SideEffect.NavigateToHome)
                 }
             }
         }

--- a/feature/fortune/src/main/java/com/yapp/fortune/FortuneViewModel.kt
+++ b/feature/fortune/src/main/java/com/yapp/fortune/FortuneViewModel.kt
@@ -4,12 +4,13 @@ import android.app.Application
 import android.util.Log
 import androidx.annotation.DrawableRes
 import androidx.lifecycle.ViewModel
+import com.yapp.domain.model.FortuneCreateStatus
 import com.yapp.domain.repository.FortuneRepository
 import com.yapp.fortune.page.toFortunePages
 import com.yapp.media.decoder.ImageUtils
 import com.yapp.media.storage.ImageSaver
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull
 import org.orbitmvi.orbit.Container
 import org.orbitmvi.orbit.ContainerHost
@@ -50,21 +51,24 @@ class FortuneViewModel @Inject constructor(
     }
 
     private fun observeFortune() = intent {
-        combine(
-            fortuneRepository.fortuneIdFlow,
-            fortuneRepository.isFirstAlarmDismissedTodayFlow,
-            fortuneRepository.isFortuneCreatingFlow,
-        ) { fortuneId: Long?, isFirstAlarmDismissedToday: Boolean, isCreating: Boolean ->
-            Triple(fortuneId, isFirstAlarmDismissedToday, isCreating)
-        }.collect { (fortuneId, isFirstAlarmDismissedToday, isCreating) ->
-            when {
-                isCreating -> {
+        fortuneRepository.fortuneCreateStatusFlow.collect { status ->
+            when (status) {
+                is FortuneCreateStatus.Creating -> {
                     reduce { state.copy(isLoading = true) }
                 }
-                fortuneId != null -> {
-                    fetchAndUpdateFortune(fortuneId, isFirstAlarmDismissedToday)
+
+                is FortuneCreateStatus.Success -> {
+                    fetchAndUpdateFortune(
+                        fortuneId = status.fortuneId,
+                        isFirstAlarmDismissedToday = fortuneRepository.isFirstAlarmDismissedTodayFlow.first(),
+                    )
                 }
-                else -> {
+
+                is FortuneCreateStatus.Failure -> {
+                    reduce { state.copy(isLoading = false) }
+                }
+
+                is FortuneCreateStatus.Idle -> {
                     reduce { state.copy(isLoading = false) }
                 }
             }

--- a/feature/fortune/src/main/java/com/yapp/fortune/worker/PostFortuneWorker.kt
+++ b/feature/fortune/src/main/java/com/yapp/fortune/worker/PostFortuneWorker.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.hilt.work.HiltWorker
 import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
+import com.yapp.domain.model.FortuneCreateStatus
 import com.yapp.domain.repository.FortuneRepository
 import com.yapp.domain.repository.UserInfoRepository
 import dagger.assisted.Assisted
@@ -20,35 +21,43 @@ class PostFortuneWorker @AssistedInject constructor(
 ) : CoroutineWorker(appContext, params) {
 
     override suspend fun doWork(): Result {
-        val hasUnseenFortune = fortuneRepository.hasUnseenFortuneFlow.first()
-        if (hasUnseenFortune) return Result.success()
-
-        val acquired = fortuneRepository.tryMarkFortuneCreating()
-        if (!acquired) return Result.success()
-
-        val userId = userInfoRepository.userIdFlow.firstOrNull()
-            ?: run {
-                fortuneRepository.markFortuneAsFailed()
-                return Result.failure()
+        when (fortuneRepository.fortuneCreateStatusFlow.first()) {
+            is FortuneCreateStatus.Creating,
+            is FortuneCreateStatus.Success,
+            -> {
+                return Result.success()
             }
+            FortuneCreateStatus.Failure,
+            FortuneCreateStatus.Idle,
+            -> {
+                val userId = userInfoRepository.userIdFlow.firstOrNull()
+                    ?: run {
+                        // 사용자 없으면 실패 상태 표시 후 실패 반환
+                        fortuneRepository.markFortuneAsFailed()
+                        return Result.failure()
+                    }
 
-        return try {
-            fortuneRepository.markFortuneAsCreating()
-            val result = fortuneRepository.postFortune(userId)
-            result.fold(
-                onSuccess = { fortune ->
-                    fortuneRepository.markFortuneAsCreated(fortune.id)
-                    fortuneRepository.saveFortuneScore(fortune.avgFortuneScore)
-                    Result.success()
-                },
-                onFailure = { e ->
+                return try {
+                    fortuneRepository.markFortuneAsCreating()
+
+                    val result = fortuneRepository.postFortune(userId)
+                    result.fold(
+                        onSuccess = { fortune ->
+                            fortuneRepository.markFortuneAsCreated(fortune.id)
+                            fortuneRepository.saveFortuneScore(fortune.avgFortuneScore)
+                            Result.success()
+                        },
+                        onFailure = {
+                            fortuneRepository.markFortuneAsFailed()
+                            // WM 백오프 규칙에 따라 재시도
+                            Result.retry()
+                        },
+                    )
+                } catch (_: Throwable) {
                     fortuneRepository.markFortuneAsFailed()
                     Result.retry()
-                },
-            )
-        } catch (_: Throwable) {
-            fortuneRepository.markFortuneAsFailed()
-            Result.retry()
+                }
+            }
         }
     }
 }

--- a/feature/mission/src/main/java/com/yapp/mission/MissionViewModel.kt
+++ b/feature/mission/src/main/java/com/yapp/mission/MissionViewModel.kt
@@ -7,6 +7,7 @@ import com.yapp.alarm.pendingIntent.interaction.createAlarmDismissIntent
 import com.yapp.analytics.AnalyticsEvent
 import com.yapp.analytics.AnalyticsHelper
 import com.yapp.domain.MissionMode
+import com.yapp.domain.model.FortuneCreateStatus
 import com.yapp.domain.model.MissionType
 import com.yapp.domain.repository.FortuneRepository
 import com.yapp.media.haptic.HapticFeedbackManager
@@ -133,13 +134,15 @@ class MissionViewModel @Inject constructor(
         performHapticSuccess()
         logMissionSuccess(type)
         if (state.missionMode == MissionMode.REAL) {
-            val hasUnseenFortune = fortuneRepository.hasUnseenFortuneFlow.first()
-            val isFortuneCreating = fortuneRepository.isFortuneCreatingFlow.first()
+            val fortuneCreateStaus = fortuneRepository.fortuneCreateStatusFlow.first()
 
-            if (hasUnseenFortune || isFortuneCreating) {
-                postSideEffect(MissionContract.SideEffect.NavigateToFortune)
-            } else {
-                postSideEffect(MissionContract.SideEffect.NavigateBack)
+            when (fortuneCreateStaus) {
+                is FortuneCreateStatus.Creating, is FortuneCreateStatus.Success -> {
+                    postSideEffect(MissionContract.SideEffect.NavigateToFortune)
+                }
+                FortuneCreateStatus.Failure, FortuneCreateStatus.Idle -> {
+                    postSideEffect(MissionContract.SideEffect.NavigateBack)
+                }
             }
         } else {
             postSideEffect(MissionContract.SideEffect.NavigateBack)


### PR DESCRIPTION
## Related issue 🛠
[//]: # (해당하는 이슈 번호 달아주기)
closed #251 

어떤 변경사항이 있었나요?
- [ ] 🐞 BugFix Something isn't working
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [ ] ✨ Feature Feature
- [x] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (Junit, etc.)

## CheckPoint ✅
[//]: # (PR 요구사항 확인)
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 컨벤션에 맞게 작성했습니다. (필수)
- [x] merge할 브랜치의 위치를 확인해 주세요(main❌/develop⭕) (필수)
- [x] Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다. (필수)
- [ ] BugFix의 경우, 버그의 원인을 파악하였습니다. (선택)

## Work Description ✏️
[//]: # (작업 내용 간단 소개)
운세 생성 상태를 hasUnseenFortune, isFortuneCreating, isFortuneFailed 플래그 대신 fortuneCreateStatusFlow로 통합 노출하도록 리팩토링

## Uncompleted Tasks 😅
[//]: # (없다면 N/A)
현재 오프라인 상태에서 운세 생성 시 API 호출이 이루어지지 않고 홈 화면으로 이동. 이후 네트워크가 연결되면 운세가 생성되지만, 사용자에게 알림이 부족한 상태

고민 중인 대응 방안:
1. 운세 화면으로 이동 후, 네트워크 연결 안내 모달을 표시
2. 기존 플로우를 유지하되, 운세 생성 완료 시 별도의 알림 제공

## To Reviewers 📢
[//]: # (reviewer가 알면 좋은 내용들)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * 행운 생성 상태를 인지해 알림/미션 완료 후 자동 이동이 더 자연스럽게 동작합니다.
* Bug Fixes
  * 중복된 행운 생성 시도를 방지하여 동일 항목이 여러 번 생성되는 문제를 완화했습니다.
  * 조건 불충분 시 홈으로 안전하게 복귀하도록 화면 전환 로직을 수정했습니다.
  * 알림에서 미션/행운 열기 동작의 신뢰성을 개선했습니다.
  * 백그라운드 작업 실패 시 적절히 재시도·실패 처리되어 안정성이 향상되었습니다.
* Refactor
  * 상태 흐름을 단일 지표로 단순화하여 화면 전환과 작업 흐름의 일관성을 높였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->