### PR TITLE
[FEATURE] Benchmark Host Activity 생성

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -38,6 +38,14 @@ android {
     }
 }
 
+androidComponents {
+    finalizeDsl { extension ->
+        extension.sourceSets.getByName("benchmarkRelease").manifest.srcFile(
+            "src/benchmarkRelease/AndroidManifest.xml",
+        )
+    }
+}
+
 dependencies {
     implementation(projects.core.common)
     implementation(projects.core.analytics)

--- a/app/src/benchmarkRelease/AndroidManifest.xml
+++ b/app/src/benchmarkRelease/AndroidManifest.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application>
+        <activity
+            android:name="com.yapp.orbit.benchmark.BenchmarkHostActivity"
+            android:exported="true"
+            android:label="@string/app_name"
+            android:theme="@style/Theme.Orbit" />
+    </application>
+</manifest>

--- a/app/src/benchmarkRelease/java/com/yapp/orbit/benchmark/BenchmarkHostActivity.kt
+++ b/app/src/benchmarkRelease/java/com/yapp/orbit/benchmark/BenchmarkHostActivity.kt
@@ -1,0 +1,61 @@
+package com.yapp.orbit.benchmark
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.ReportDrawnWhen
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.sp
+import com.yapp.designsystem.theme.OrbitTheme
+
+internal const val EXTRA_BENCHMARK_SCREEN = "benchmark_screen_key"
+internal const val BENCHMARK_SCREEN_ORBIT_PICKER = "orbit_picker"
+internal const val BENCHMARK_UNKNOWN_SCREEN_ROOT = "benchmark_unknown_screen"
+
+class BenchmarkHostActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        val screenKey = intent?.getStringExtra(EXTRA_BENCHMARK_SCREEN)
+        setContent {
+            OrbitTheme {
+                BenchmarkScreenContainer(screenKey)
+            }
+        }
+    }
+}
+
+@Composable
+private fun BenchmarkScreenContainer(screenKey: String?) {
+    when (screenKey) {
+        BENCHMARK_SCREEN_ORBIT_PICKER -> OrbitPickerBenchmarkScreen()
+        else -> BenchmarkScreenMissing(screenKey)
+    }
+}
+
+@Composable
+private fun BenchmarkScreenMissing(requestedKey: String?) {
+    ReportDrawnWhen { true }
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(OrbitTheme.colors.gray_900)
+            .semantics { contentDescription = BENCHMARK_UNKNOWN_SCREEN_ROOT },
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = "Benchmark screen '${requestedKey ?: "unknown"}' not registered.",
+            color = OrbitTheme.colors.white,
+            fontSize = 16.sp,
+            fontWeight = FontWeight.SemiBold,
+        )
+    }
+}

--- a/app/src/benchmarkRelease/java/com/yapp/orbit/benchmark/OrbitPickerBenchmarkScreen.kt
+++ b/app/src/benchmarkRelease/java/com/yapp/orbit/benchmark/OrbitPickerBenchmarkScreen.kt
@@ -1,0 +1,68 @@
+package com.yapp.orbit.benchmark
+
+import androidx.activity.compose.ReportDrawnWhen
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.yapp.designsystem.theme.OrbitTheme
+import com.yapp.ui.component.timepicker.OrbitPicker
+import java.time.LocalTime
+
+internal const val ORBIT_PICKER_BENCHMARK_ROOT = "orbit_picker_root"
+
+@Composable
+internal fun OrbitPickerBenchmarkScreen(
+    modifier: Modifier = Modifier,
+    initialTime: LocalTime = LocalTime.of(8, 30),
+) {
+    var selectedTime by remember { mutableStateOf(initialTime) }
+    var isDrawn by remember { mutableStateOf(false) }
+
+    ReportDrawnWhen { isDrawn }
+
+    LaunchedEffect(Unit) {
+        isDrawn = true
+    }
+
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .background(OrbitTheme.colors.gray_900)
+            .semantics { contentDescription = ORBIT_PICKER_BENCHMARK_ROOT },
+        contentAlignment = Alignment.Center,
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center,
+            modifier = Modifier.padding(horizontal = 24.dp),
+        ) {
+            OrbitPicker(
+                initialTime = selectedTime,
+                onValueChange = { selectedTime = it },
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun OrbitPickerBenchmarkPreview() {
+    OrbitTheme {
+        OrbitPickerBenchmarkScreen()
+    }
+}

--- a/baselineprofile/src/main/java/com/dongchyeon/baselineprofile/OrbitPickerBenchmarks.kt
+++ b/baselineprofile/src/main/java/com/dongchyeon/baselineprofile/OrbitPickerBenchmarks.kt
@@ -1,0 +1,76 @@
+package com.dongchyeon.baselineprofile
+
+import android.content.ComponentName
+import android.content.Intent
+import androidx.benchmark.macro.CompilationMode
+import androidx.benchmark.macro.FrameTimingMetric
+import androidx.benchmark.macro.StartupMode
+import androidx.benchmark.macro.junit4.MacrobenchmarkRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.LargeTest
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.uiautomator.By
+import androidx.test.uiautomator.Until
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+@LargeTest
+class OrbitPickerBenchmarks {
+
+    @get:Rule
+    val rule = MacrobenchmarkRule()
+
+    @Test
+    fun orbitPickerScrollCompilationNone() = benchmark(CompilationMode.None())
+
+    @Test
+    fun orbitPickerScrollCompilationBaselineProfile() = benchmark(CompilationMode.Partial())
+
+    private fun benchmark(compilationMode: CompilationMode) {
+        val targetPackage = InstrumentationRegistry.getArguments().getString("targetAppId")
+            ?: throw IllegalStateException("targetAppId not passed as instrumentation runner arg")
+
+        rule.measureRepeated(
+            packageName = targetPackage,
+            metrics = listOf(FrameTimingMetric()),
+            compilationMode = compilationMode,
+            startupMode = StartupMode.COLD,
+            iterations = 10,
+            setupBlock = {
+                killProcess()
+                pressHome()
+            },
+            measureBlock = {
+                val intent = Intent().apply {
+                    component = ComponentName(targetPackage, BENCHMARK_ACTIVITY_NAME)
+                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                    putExtra(BENCHMARK_SCREEN_EXTRA, ORBIT_PICKER_SCREEN_KEY)
+                }
+
+                startActivityAndWait(intent)
+
+                device.wait(Until.hasObject(By.desc(ORBIT_PICKER_SEMANTICS)), 5_000)
+                val picker = device.findObject(By.desc(ORBIT_PICKER_SEMANTICS))
+                    ?: error("OrbitPicker root not found")
+
+                val bounds = picker.visibleBounds
+                val x = bounds.centerX() + bounds.width() / 4
+                val startY = bounds.centerY() + bounds.height() / 4
+                val endY = bounds.centerY() - bounds.height() / 4
+
+                device.swipe(x, startY, x, endY, 30)
+                device.waitForIdle()
+            },
+        )
+    }
+
+    private companion object {
+        private const val BENCHMARK_ACTIVITY_NAME =
+            "com.yapp.orbit.benchmark.BenchmarkHostActivity"
+        private const val BENCHMARK_SCREEN_EXTRA = "benchmark_screen_key"
+        private const val ORBIT_PICKER_SCREEN_KEY = "orbit_picker"
+        private const val ORBIT_PICKER_SEMANTICS = "orbit_picker_root"
+    }
+}


### PR DESCRIPTION
## Related issue 🛠
[//]: # (해당하는 이슈 번호 달아주기)
closed #275 

어떤 변경사항이 있었나요?
- [ ] 🐞 BugFix Something isn't working
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [x] ✨ Feature Feature
- [ ] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (Junit, etc.)

## CheckPoint ✅
[//]: # (PR 요구사항 확인)
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 컨벤션에 맞게 작성했습니다. (필수)
- [x] merge할 브랜치의 위치를 확인해 주세요(main❌/develop⭕) (필수)
- [x] Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다. (필수)
- [ ] BugFix의 경우, 버그의 원인을 파악하였습니다. (선택)

## Work Description ✏️
[//]: # (작업 내용 간단 소개)
- 네비게이션 로직 없이 화면 단위, UI 단위 성능 벤치마크를 용이하게 하기 위해 BenchmarkHostActivity 구현
- Intent를 통해 벤치마크할 요소를 결정

### OrbitPicker (타임피커) 개선 전(aed700e4) 과 개선 후 벤치마크 결과
- 개선 전
  ```
  OrbitPickerBenchmarks_orbitPickerScrollCompilationNone
  frameCount           min   5.0,   median   6.0,   max   6.0
  frameDurationCpuMs   P50   18.3,   P90   58.2,   P95   59.5,   P99   63.1
  frameOverrunMs       P50   26.9,   P90  203.5,   P95  219.1,   P99  221.2
  Traces: Iteration 0 1 2 3 4 5 6 7 8 9
  
  OrbitPickerBenchmarks_orbitPickerScrollCompilationBaselineProfile
  frameCount           min   6.0,   median   6.0,   max   6.0
  frameDurationCpuMs   P50    9.8,   P90   48.6,   P95   52.3,   P99   60.5
  frameOverrunMs       P50    6.1,   P90  185.0,   P95  220.5,   P99  289.6
  Traces: Iteration 0 1 2 3 4 5 6 7 8 9
  ```
- 개선 후
  ```
  OrbitPickerBenchmarks_orbitPickerScrollCompilationNone
  frameCount           min   5.0,   median   6.0,   max   6.0
  frameDurationCpuMs   P50   14.6,   P90   64.1,   P95   76.8,   P99   83.0
  frameOverrunMs       P50    8.8,   P90  206.7,   P95  224.5,   P99  256.9
  Traces: Iteration 0 1 2 3 4 5 6 7 8 9
  
  OrbitPickerBenchmarks_orbitPickerScrollCompilationBaselineProfile
  frameCount           min   6.0,   median   6.0,   max   6.0
  frameDurationCpuMs   P50   10.2,   P90   46.0,   P95   49.2,   P99   92.1
  frameOverrunMs       P50    0.4,   P90  191.7,   P95  205.1,   P99  223.7
  Traces: Iteration 0 1 2 3 4 5 6 7 8 9
  ```

### P50 성능 비교표

| Benchmark Type                         | Metric                | Before  | After   | Change          |
|----------------------------------------|-----------------------|---------|---------|-----------------|
| BaselineProfile (CompilationBaseline)  | frameDurationCpuMs    | 9.8 ms  | 10.2 ms | +0.4 ms (≈ 동일) |
| BaselineProfile (CompilationBaseline)  | frameOverrunMs        | 6.1 ms  | 0.4 ms  | -5.7 ms (개선)  |
| CompilationNone                        | frameDurationCpuMs    | 18.3 ms | 14.6 ms | -3.7 ms (개선)  |
| CompilationNone                        | frameOverrunMs        | 26.9 ms | 8.8 ms  | -18.1 ms (대폭 개선) |

## Uncompleted Tasks 😅
[//]: # (없다면 N/A)
N/A

## To Reviewers 📢
[//]: # (reviewer가 알면 좋은 내용들)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 성능 측정을 위한 벤치마킹 인프라가 추가되었습니다.
  * 벤치마크 테스트 환경 및 테스트 화면이 구현되었습니다.
  * OrbitPicker 컴포넌트에 대한 벤치마크 테스트 케이스가 추가되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->